### PR TITLE
调整更大的padding-bottom值

### DIFF
--- a/examples/category.vue
+++ b/examples/category.vue
@@ -66,7 +66,7 @@ block()
   float left
   width 100%
 .md-cg
-  padding 20px
+  padding 20px 20px 50px
   clearfix()
   .md-cg-title
     block()


### PR DESCRIPTION
目前滑到最底下的时候，copyright 信息会有部分被遮盖，调大 padding-bottom 值，让 copyright 信息显示完整