### PR TITLE
fix(picker):given a default itemIndex when both defaultIndex & default…

### DIFF
--- a/components/picker/picker-column.vue
+++ b/components/picker/picker-column.vue
@@ -233,8 +233,18 @@ export default {
       traverse(data, (item, level, indexs) => {
         const columnIndex = indexs[0]
         const itemIndex = indexs[1]
-        const itemDefaultIndex = defaultIndex[columnIndex]
+        let itemDefaultIndex = defaultIndex[columnIndex]
         const itemDefaultValue = defaultValue[columnIndex]
+
+        /* 
+         * given a default itemIndex when both defaultIndex & defaultValue are undefined
+         * avoid activieIndexs failing to initialize
+         */
+        if (itemDefaultIndex === undefined && itemDefaultValue === undefined) {
+          itemDefaultIndex = 0
+        }
+
+        // get initial itemIndex of each columnIndex by defaultIndex or defaultValue
         if (
           (itemDefaultIndex !== undefined && itemIndex === itemDefaultIndex) ||
           (itemDefaultValue !== undefined &&


### PR DESCRIPTION
Given a default `itemIndex`(0) when both `defaultIndex` & `defaultValue` are undefined to avoid `activieIndexs` failing to initialize.

---- 

当`defaultIndex` 和 `defaultValue` 都为设置时，默认设置每列的`itemIndex`为0。否则`activieIndexs`无法初始化。