### PR TITLE
fix(picker): picker 恰好选中invalid项无需滚动的时候，可以选中invalid项

### DIFF
--- a/components/_util/scroller.js
+++ b/components/_util/scroller.js
@@ -664,6 +664,9 @@ export default class Scroller {
       }
     }
 
+    // execute handle
+    this.options.scrollingComplete()
+
     // Fully cleanup list
     this._positions.length = 0
   }


### PR DESCRIPTION
fix(picker): picker 恰好选中invalid项无需滚动时候，没有执行picker-column中的$_onColumnScrollEnd，即scroller中的scrollingComplete，造成可以选中invalid项