### PR TITLE
fix(input-item): remove prop key when use error slot

### DIFF
--- a/components/input-item/demo/cases/demo5.vue
+++ b/components/input-item/demo/cases/demo5.vue
@@ -12,7 +12,6 @@
         type="bankCard"
         title="储蓄卡号"
         v-model="bankCardNo"
-        :key="bankCardKey"
         clearable
         @blur="checkBankCard"
       >
@@ -43,7 +42,6 @@ export default {
   data() {
     return {
       bankCardNo: '',
-      bankCardKey: Date.now(),
       isError: false,
     }
   },
@@ -54,7 +52,6 @@ export default {
       } else {
         this.isError = false
       }
-      this.bankCardKey = Date.now()
     },
     bankCardTip() {
       Dialog.alert({

--- a/components/input-item/index.vue
+++ b/components/input-item/index.vue
@@ -6,8 +6,8 @@
       isTitleLatent ? 'is-title-latent' : '',
       isInputActive ? 'is-active' : '',
       isInputFocus ? 'is-focus' : '',
-      isInputError ? 'is-error' : '',
-      isInputBrief ? 'with-brief' : '',
+      isInputError() ? 'is-error' : '',
+      isInputBrief && !isInputError() ? 'with-brief' : '',
       isDisabled ? 'is-disabled': '',
       isAmount ? 'is-amount': '',
       clearable ? 'is-clear' : '',
@@ -86,14 +86,14 @@
       <!-- BRIEF/ERROR TIP -->
       <!-- -------------------- -->
       <div
-        v-if="isInputError"
+        v-if="isInputError()"
         class="md-input-item-msg"
       >
         <p v-if="error !== ''" v-text="error"></p>
         <slot name="error" v-else></slot>
       </div>
       <div
-        v-if="isInputBrief"
+        v-if="isInputBrief && !isInputError()"
         class="md-input-item-brief"
       >
         <p v-if="brief !== ''" v-text="brief"></p>
@@ -276,11 +276,8 @@ export default {
     isInputEmpty() {
       return !this.inputValue.length
     },
-    isInputError() {
-      return this.$slots.error || this.error !== ''
-    },
     isInputBrief() {
-      return (this.$slots.brief || this.brief !== '') && !this.isInputError
+      return this.$slots.brief || this.brief !== ''
     },
     isDisabled() {
       return this.rootField.disabled || this.disabled
@@ -313,7 +310,6 @@ export default {
       }
     },
   },
-
   created() {
     this.inputValue = this.$_formateValue(this.$_subValue(this.value + '')).value
   },
@@ -426,6 +422,9 @@ export default {
       const keyboard = this.$refs['number-keyboard']
       this.inputNumberKeyboard = keyboard
       document.body.appendChild(keyboard.$el)
+    },
+    isInputError() {
+      return this.$slots.error || this.error !== ''
     },
 
     // MARK: events handler
@@ -662,7 +661,7 @@ export default {
     .md-input-item-input::-webkit-input-placeholder
         font-size 60px
         line-height 100px
-      
+
   &.is-error
     .md-field-item-content
       hairline(bottom, input-item-color-error, 0, 4px)


### PR DESCRIPTION
input-item 在使用error-slot 时省去使用key