### PR TITLE
fix(codebox): fix the bottom border of codebox is not visible in oppo r9m

### DIFF
--- a/components/codebox/index.vue
+++ b/components/codebox/index.vue
@@ -253,6 +253,7 @@ export default {
       flex 1 1 0%
 
 .md-codebox-box
+  position relative
   flex 0 1 codebox-width
   width codebox-width
   height codebox-height
@@ -271,7 +272,7 @@ export default {
     margin-left "calc(%s / 2)" % codebox-gutter
     margin-right "calc(%s / 2)" % codebox-gutter
 
-  border-bottom codebox-border-width solid codebox-border-color
+  hairline(bottom, color-border-element)
   &:first-child
     margin-left 0
   &:last-child


### PR DESCRIPTION
修复codebox底部边框在oppo r9m中不可见的问题