### PR TITLE
fix(swiper): fix incorrect index jumping with method goto

### DIFF
--- a/components/swiper/test/index.spec.js
+++ b/components/swiper/test/index.spec.js
@@ -140,7 +140,7 @@ describe('Swiper', () => {
       expect(wrapper.vm.getIndex()).toBe(0)
 
       wrapper.vm.goto(3) // ill
-      expect(wrapper.vm.getIndex()).toBe(0)
+      expect(wrapper.vm.getIndex()).toBe(2)
 
       wrapper.vm.goto(2)
       expect(wrapper.vm.getIndex()).toBe(2)


### PR DESCRIPTION
### 背景描述
 is-loop为true时，调用`goto`时跳转异常

### 主要改动

*  区分`real index`(swiper内部items的真实索引)，`display index`(用户视角的swiper index)
* 增加两个方法`$_calcDisplayIndex`(将`display index`转换为`real index`)，`$_calcRealIndex`(将`real index`转换为`display index`)
* 调用goto时，先把`display index`转换为`real index`
* 调用goto时，需重启定时器，否则跳转完可能会立马又跳走