### PR TITLE
fix(date-picker): support HH in custom-types

### DIFF
--- a/components/date-picker/index.vue
+++ b/components/date-picker/index.vue
@@ -37,6 +37,7 @@ const TYPE_FORMAT = {
   'yyyy': 'Year',
   'MM': 'Month',
   'dd': 'Date',
+  'HH': 'Hour',
   'hh': 'Hour',
   'mm': 'Minute'
 }
@@ -553,7 +554,8 @@ export default {
         if (value < 10) {
           value = '0' + value
         }
-
+        
+        format = format.replace('HH', 'hh') // deal with HH as hh
         format = format.replace(item.type, value)
         format = format.replace(TYPE_FORMAT_INVERSE[item.type], value)
       })


### PR DESCRIPTION
### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
DatePicker中的小时目前只支持24小时制，但custom-types中的小时用hh表示，所以增加HH支持

### 主要改动
<!-- 列举具体改动点 -->
1. custom-types 中支持 HH
2. getFormatDate 中支持 HH

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->
回归