### PR TITLE
feat(tab-picker):add select event & optimize container scrolltop

### DIFF
--- a/components/tab-picker/README.en-US.md
+++ b/components/tab-picker/README.en-US.md
@@ -51,6 +51,18 @@ Get all options of selected items
 
 #### TabPicker Events
 
+##### @select(data)
+Option selected event
+
+```
+// data对象
+{
+  index: 0,
+  value: 'value1',
+  options: { value: 'value1', label: 'Item1' }
+}
+```
+
 ##### @change(data)
 Change selection in the tabpicker
 

--- a/components/tab-picker/README.md
+++ b/components/tab-picker/README.md
@@ -52,6 +52,18 @@ Vue.component(TabPicker.name, TabPicker)
 
 #### TabPicker 事件
 
+##### @select(data)
+选项选中事件
+
+```
+// data对象
+{
+  index: 0,
+  value: 'value1',
+  options: { value: 'value1', label: 'Item1' }
+}
+```
+
 ##### @change(data)
 底部弹窗选中事件
 

--- a/components/tab-picker/index.vue
+++ b/components/tab-picker/index.vue
@@ -21,7 +21,11 @@
             v-model="currentTab"
             ref="tabs"
           >
-            <md-scroll-view :scrolling-x="false" auto-reflow>
+            <md-scroll-view
+              ref="scrollView"
+              :scrolling-x="false"
+              auto-reflow
+            >
               <md-tab-pane
                 v-for="(pane, index) in panes"
                 :key="pane.name"
@@ -197,9 +201,16 @@ export default {
       this.$nextTick(() => {
         const nextPane = this.panes[index + 1]
 
+        this.$emit('select', {
+          index,
+          value,
+          option: this.panes[index],
+        })
+
         /* istanbul ignore else */
         if (nextPane) {
           this.currentTab = nextPane.name
+          this.$refs.scrollView.scrollTo(0, 0)
         } else if (value !== '') {
           setTimeout(() => {
             this.$emit('change', {


### PR DESCRIPTION
### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
1. 目前只有一个全部tab选项选择完成的`change`事件，缺乏每一级tab选中事件 #435 
2. 上一级tab选中时可能会滚动容器(`ScrollView`)，选中某项后切换到下一级tab，容器未回到顶部

### 主要改动
<!-- 列举具体改动点 -->
1. 选项选中时，触发select事件
2. 选项选中后，`ScrollView`滚回顶部

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->
回归
