### PR TITLE
fix(radio-list): clear input item when changing selected option

### DIFF
--- a/components/radio/list.vue
+++ b/components/radio/list.vue
@@ -160,6 +160,7 @@ export default {
     $_select(option, index) {
       this.selectedValue = option.value
       this.inputSelected = false
+      this.inputValue && (this.inputValue = '')
       this.$emit('change', option, index)
     },
     // MARK: public methods


### PR DESCRIPTION
### 背景描述
radio-list 使用时，先在input中输入，再选择radio时，input并没有置空

### 主要改动
radio-list 使用时，先在input中输入，再选择radio时，input置空

### 需要注意
无
