### PR TITLE
fix(tab-bar): supplement scrolling of the first and last options

### DIFF
--- a/components/tab-bar/index.vue
+++ b/components/tab-bar/index.vue
@@ -211,9 +211,19 @@ export default {
         const prevTarget = this.$refs.items[this.currentIndex - 1]
         const nextTarget = this.$refs.items[this.currentIndex + 1]
 
+        if (!prevTarget) {
+          this.$refs.scroller.scrollTo(0, 0, true)
+          return
+        }
+
+        if (!nextTarget) {
+          this.$refs.scroller.scrollTo(this.wrapperW, 0, true)
+          return
+        }
+
         const wrapperRect = this.$refs.wrapper.getBoundingClientRect()
-        const prevTargetRect = prevTarget && prevTarget.getBoundingClientRect()
-        const nextTargetRect = nextTarget && nextTarget.getBoundingClientRect()
+        const prevTargetRect = prevTarget.getBoundingClientRect()
+        const nextTargetRect = nextTarget.getBoundingClientRect()
 
         /* istanbul ignore next */
         if (prevTargetRect && prevTargetRect.left < wrapperRect.left) {


### PR DESCRIPTION
<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
首尾两个选项位于部分露出的位置时，选中后无法自动滚动至合适位置。

### 主要改动
<!-- 列举具体改动点 -->
`prevTarget`或`nextTarget`为空时，`scroller`需分别最左侧和最右侧。

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->
无

<!-- PR 内容区 -->