### PR TITLE
feat(radioList):add props for slot-scope & add removing icon configration

### DIFF
--- a/components/radio/list.vue
+++ b/components/radio/list.vue
@@ -17,10 +17,10 @@
       @click="$_select(item, index)"
     >
       <template v-if="hasSlot">
-        <slot :option="item"></slot>
+        <slot :option="item" :index="index" :selected="currentValue === item.value"></slot>
       </template>
       <md-radio
-        v-if="!alignCenter && !inputSelected"
+        v-if="!alignCenter && !inputSelected && !withoutIcon"
         :name="item.value"
         v-model="selectedValue"
         :disabled="item.disabled"
@@ -96,6 +96,10 @@ export default {
       type: Boolean,
       default: undefined,
     },
+    noIcon: {
+      type: Boolean,
+      default: false,
+    },
     // Mixin Props
     // icon: {
     //   type: String,
@@ -141,6 +145,9 @@ export default {
     },
     hasSlot() {
       return this.isSlotScope !== undefined ? this.isSlotScope : !!this.$scopedSlots.default
+    },
+    withoutIcon() {
+      return this.isSlotScope && this.noIcon
     },
   },
 

--- a/components/radio/list.vue
+++ b/components/radio/list.vue
@@ -96,10 +96,6 @@ export default {
       type: Boolean,
       default: undefined,
     },
-    noIcon: {
-      type: Boolean,
-      default: false,
-    },
     // Mixin Props
     // icon: {
     //   type: String,
@@ -147,7 +143,7 @@ export default {
       return this.isSlotScope !== undefined ? this.isSlotScope : !!this.$scopedSlots.default
     },
     withoutIcon() {
-      return this.isSlotScope && this.noIcon
+      return this.isSlotScope && !this.icon
     },
   },
 


### PR DESCRIPTION
<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
为 radioList 新增了一个 'noIcon' 的属性， 需要配合 'is-slot-scope' 使用。因为当我们有需求使用 slot-scope 的时候，甚至连 icon 都不需要；当我 把 iconname 都设置为空时，图标区域仍有一个 margin-left 影响布局。同时，slot-scope v-bind的值过少，导致使用不便，我增加了两个新的 props: index, selected 以省去父组件部分的计算内容。
### 主要改动
<!-- 列举具体改动点 -->
radioList 新增一个 props:  noIcon: boolean
slot-scope 新增两个属性： index: number, selected: boolean
### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->
1、radioList 代码
<!-- PR 内容区 -->
