### PR TITLE
feat(scroll-view): add prop is-prevent

### DIFF
--- a/components/scroll-view/README.en-US.md
+++ b/components/scroll-view/README.en-US.md
@@ -35,6 +35,11 @@ Vue.component(ScrollView.name, ScrollView)
 |end-reached-threshold | threshold for emitting `endReached`. | Number | 0 | unit `px` |
 |immediate-check-end-reaching <sup class="version-after">2.1.0+</sup>| check if it reaches the bottom at initialization | Boolean | `false` | - |
 |touch-angle <sup class="version-after">2.1.0+</sup>| angle value range that triggers scrolling | Number | 45 | unit `deg` |
+|is-prevent <sup class="version-after">2.3.0+</sup>| prevent browser default scrolling | Boolean | `true` | if set to `false`, the browser defaults to scroll when scrolling is triggered over a non-scrollable angle range |
+
+#### ScrollView TouchAngle
+
+<img src="https://pt-starimg.didistatic.com/static/starimg/img/cSL4mjxTmW1560240984431.jpg" width="460"/>
 
 #### ScrollViewRefresh Props
 |Props | Description | Type | Default | Note |

--- a/components/scroll-view/README.md
+++ b/components/scroll-view/README.md
@@ -35,6 +35,11 @@ Vue.component(ScrollView.name, ScrollView)
 |end-reached-threshold | 触发到达底部的提前量 | Number | 0 | 单位`px` |
 |immediate-check-end-reaching <sup class="version-after">2.1.0+</sup>| 初始化时立即触发是否到达底部检查 | Boolean | `false` | - |
 |touch-angle <sup class="version-after">2.1.0+</sup>| 触发滚动的角度范围 | Number | 45 | 单位`deg` |
+|is-prevent <sup class="version-after">2.3.0+</sup>| 阻止浏览器默认滚动 | Boolean | `true` | 如果设置为`false`，当在非可滚动角度范围触发滚动时会触发浏览器默认滚动 |
+
+#### ScrollView TouchAngle
+
+<img src="https://pt-starimg.didistatic.com/static/starimg/img/cSL4mjxTmW1560240984431.jpg" width="460"/>
 
 #### ScrollViewRefresh Props
 |属性 | 说明 | 类型 | 默认值 | 备注|

--- a/components/scroll-view/demo/cases/demo1.vue
+++ b/components/scroll-view/demo/cases/demo1.vue
@@ -3,6 +3,8 @@
     <md-scroll-view
       ref="scrollView"
       :scrolling-y="false"
+      :touch-angle="80"
+      :is-prevent="false"
     >
       <div class="scroll-view-list">
         <p
@@ -22,6 +24,8 @@ export default {
   /* DELETE */
   title: '横向滚动',
   titleEnUS: 'Horizontal scrolling',
+  describe: 'isPrevent false, touchAngle 80',
+  describEnUs: 'isPrevent false, touchAngle 80',
   /* DELETE */
   components: {
     [ScrollView.name]: ScrollView,

--- a/components/scroll-view/index.vue
+++ b/components/scroll-view/index.vue
@@ -49,8 +49,7 @@
   </div>
 </template>
 
-<script>
-import {debounce} from '../_util'
+<script>import {debounce} from '../_util'
 import Scroller from '../_util/scroller'
 import {render} from '../_util/render'
 
@@ -88,6 +87,10 @@ export default {
     touchAngle: {
       type: Number,
       default: 45,
+    },
+    isPrevent: {
+      type: Boolean,
+      default: true,
     },
   },
   data() {
@@ -248,7 +251,10 @@ export default {
       if (!this.scroller) {
         return
       }
-      event.preventDefault()
+
+      if (this.isPrevent) {
+        event.preventDefault()
+      }
 
       this.currentX = event.targetTouches[0].pageX
       this.currentY = event.targetTouches[0].pageY
@@ -260,6 +266,10 @@ export default {
         }
       }
 
+      if (!this.isPrevent) {
+        event.preventDefault()
+      }
+
       this.scroller.doTouchMove(event.touches, event.timeStamp, event.scale)
 
       const boundaryDistance = 15
@@ -268,7 +278,12 @@ export default {
 
       const pX = this.currentX - scrollLeft
       const pY = this.currentY - scrollTop
-      if (pX > document.documentElement.clientWidth - boundaryDistance || pY > document.documentElement.clientHeight - boundaryDistance || pX < boundaryDistance || pY < boundaryDistance) {
+      if (
+        pX > document.documentElement.clientWidth - boundaryDistance ||
+        pY > document.documentElement.clientHeight - boundaryDistance ||
+        pX < boundaryDistance ||
+        pY < boundaryDistance
+      ) {
         this.scroller.doTouchEnd(event.timeStamp)
       }
     },
@@ -412,8 +427,7 @@ export default {
     },
   },
 }
-
-</script>
+</script>
 
 <style lang="stylus">
 .md-scroll-view

--- a/components/scroll-view/index.vue
+++ b/components/scroll-view/index.vue
@@ -1,14 +1,14 @@
 <template>
   <div
     class="md-scroll-view"
-    @touchstart="$_onScollerTouchStart"
-    @touchmove="$_onScollerTouchMove"
-    @touchend="$_onScollerTouchEnd"
-    @touchcancel="$_onScollerTouchEnd"
-    @mousedown="$_onScollerMouseDown"
-    @mousemove="$_onScollerMouseMove"
-    @mouseup="$_onScollerMouseUp"
-    @mouseleave="$_onScollerMouseUp"
+    @touchstart="$_onScrollerTouchStart"
+    @touchmove="$_onScrollerTouchMove"
+    @touchend="$_onScrollerTouchEnd"
+    @touchcancel="$_onScrollerTouchEnd"
+    @mousedown="$_onScrollerMouseDown"
+    @mousemove="$_onScrollerMouseMove"
+    @mouseup="$_onScrollerMouseUp"
+    @mouseleave="$_onScrollerMouseUp"
   >
     <div class="scroll-view-header" v-if="$slots.header">
       <slot name="header"></slot>
@@ -236,7 +236,7 @@ export default {
       return this.scrollingX ? 90 - angle : angle
     },
     // MARK: events handler
-    $_onScollerTouchStart(event) {
+    $_onScrollerTouchStart(event) {
       // event.target.tagName && event.target.tagName.match(/input|textarea|select/i)
       /* istanbul ignore if */
       if (!this.scroller) {
@@ -246,7 +246,7 @@ export default {
       this.startY = event.targetTouches[0].pageY
       this.scroller.doTouchStart(event.touches, event.timeStamp)
     },
-    $_onScollerTouchMove(event) {
+    $_onScrollerTouchMove(event) {
       /* istanbul ignore if */
       if (!this.scroller) {
         return
@@ -269,7 +269,9 @@ export default {
         }
       }
 
-      !hadPrevent && event.preventDefault()
+      if (!hadPrevent && event.cancelable) {
+        event.preventDefault()
+      }
 
       this.scroller.doTouchMove(event.touches, event.timeStamp, event.scale)
 
@@ -288,14 +290,14 @@ export default {
         this.scroller.doTouchEnd(event.timeStamp)
       }
     },
-    $_onScollerTouchEnd(event) {
+    $_onScrollerTouchEnd(event) {
       /* istanbul ignore if */
       if (!this.scroller) {
         return
       }
       this.scroller.doTouchEnd(event.timeStamp)
     },
-    $_onScollerMouseDown(event) {
+    $_onScrollerMouseDown(event) {
       /* istanbul ignore if */
       if (!this.scroller) {
         return
@@ -313,7 +315,7 @@ export default {
       )
       this.isMouseDown = true
     },
-    $_onScollerMouseMove(event) {
+    $_onScrollerMouseMove(event) {
       /* istanbul ignore if */
       if (!this.scroller || !this.isMouseDown) {
         return
@@ -338,7 +340,7 @@ export default {
       )
       this.isMouseDown = true
     },
-    $_onScollerMouseUp(event) {
+    $_onScrollerMouseUp(event) {
       /* istanbul ignore if */
       if (!this.scroller || !this.isMouseDown) {
         return

--- a/components/scroll-view/index.vue
+++ b/components/scroll-view/index.vue
@@ -251,9 +251,12 @@ export default {
       if (!this.scroller) {
         return
       }
+      let hadPrevent = false
 
       if (this.isPrevent) {
         event.preventDefault()
+
+        hadPrevent = true
       }
 
       this.currentX = event.targetTouches[0].pageX
@@ -266,9 +269,7 @@ export default {
         }
       }
 
-      if (!this.isPrevent) {
-        event.preventDefault()
-      }
+      !hadPrevent && event.preventDefault()
 
       this.scroller.doTouchMove(event.touches, event.timeStamp, event.scale)
 


### PR DESCRIPTION
<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
通过新增属性`is-prevent`设置，当在非可滚动区域触发滚动时，是否也阻止默认行为。如在横向滚动区域触发纵向滚动，需触发浏览器默认滚动的场景 #454 

### 主要改动
<!-- 列举具体改动点 -->
增加`is-prevent`，以控制是否调用`touchmove`内部的前置`event.preventDefault()`

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->

<!-- PR 内容区 -->