### PR TITLE
fix(slider): fix wrong slider-bar display bug without range in min & max

### DIFF
--- a/components/slider/index.vue
+++ b/components/slider/index.vue
@@ -115,14 +115,16 @@
       return (this.values[1] - this.min) / (this.max - this.min) * 100
     },
     barStyle() {
-      if (this.range) {
+      const {range, values, min, max, lowerHandlePosition} = this
+
+      if (range) {
         return {
-          width: (this.values[1] - this.values[0]) / (this.max - this.min) * 100 + '%',
-          left: this.lowerHandlePosition + '%',
+          width: (values[1] - values[0]) / (max - min) * 100 + '%',
+          left: lowerHandlePosition + '%',
         }
       } else {
         return {
-          width: this.values[0] / (this.max - this.min) * 100 + '%',
+          width: (values[0] - min) / (max - min) * 100 + '%',
         }
       }
     },


### PR DESCRIPTION
fix #472

### 背景描述
slider在range为false时，设置min & max，组件显示不正确。因为计算长度的时候并没有将min的值减去导致的。

### 主要改动
range为false时，计算barStyle会减去min

### 需要注意
无
