### PR TITLE
fix(codebox): fix codebox with wrong watch options

### DIFF
--- a/components/codebox/index.vue
+++ b/components/codebox/index.vue
@@ -139,7 +139,7 @@ export default {
   },
   watch: {
     value: {
-      imediate: true,
+      immediate: true,
       handler(val) {
         if (val !== this.code) {
           this.code = val


### PR DESCRIPTION
### 背景描述
codebox的watch value的immediate拼写错误

### 主要改动
修改正确的拼写

### 需要注意
无
