### PR TITLE
fix(check-list): fix check-list click md-icon bug

### DIFF
--- a/components/check/index.vue
+++ b/components/check/index.vue
@@ -47,6 +47,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    isPrevent: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   computed: {
@@ -64,6 +68,10 @@ export default {
 
   methods: {
     $_onClick() {
+      if (this.isPrevent) {
+        return
+      }
+
       if (this.disabled) {
         return
       }

--- a/components/check/list.vue
+++ b/components/check/list.vue
@@ -31,6 +31,7 @@
         :icon-disabled="iconDisabled"
         :icon-svg="iconSvg"
         :slot="iconPosition === 'right' ? 'right' : 'left'"
+        :is-prevent="true"
       />
     </md-cell-item>
   </md-check-group>


### PR DESCRIPTION
fix #491

### 背景描述
check-list组件、selector组件（多选模式使用了check-list），点击icon没有反应。
check-list中引用了check组件，而check组件在点击的时候会调用inject中rootGroup的check方法，同时也触发了父级cell-item的click事件（也对rootGroup的调用了toggle），就导致方法被调用两次，出现没有响应的情况。

### 主要改动
check增加isPrevent属性，默认false，为true的时候，不做任何操作（行为与disabled一致，但不会更改样式）

### 需要注意
无
