### PR TITLE
fix(check-list): fix click md-icon without any action bug

### DIFF
--- a/components/check/list.vue
+++ b/components/check/list.vue
@@ -101,6 +101,7 @@ export default {
   .md-check
     margin-top 0
     margin-bottom 0
+    pointer-events none
   .md-cell-item-body.multilines .md-cell-item-title
     font-weight font-weight-medium
 


### PR DESCRIPTION
fix #491

### 背景描述
check-list、selector(多选模式使用check-list)点击icon时，没有反应。原因是check-list内置了md-check，点击icon时触发了md-check向inject中rootGroup的check方法，同时也触发了check-list的click回调再次调用rootGroup的toggle方法，导致重复调用出现bug

### 主要改动
check-list中对md-check阻止默认行为

### 需要注意
无