### PR TITLE
fix(tab-picker): some exceptions in tabs rendering

### DIFF
--- a/components/tab-picker/index.vue
+++ b/components/tab-picker/index.vue
@@ -19,6 +19,7 @@
       <div class="md-tab-picker-content">
           <md-tabs
             v-model="currentTab"
+            :key="tabsTmpKey"
             ref="tabs"
           >
             <md-scroll-view
@@ -36,7 +37,6 @@
                   :value="pane.value"
                   :options="pane.options"
                   :is-slot-scope="hasSlot"
-                  :key="tabsTmpKey"
                   @input="$_onSelectPaneItem($event, index)"
                   icon=""
                   icon-inverse=""
@@ -151,6 +151,7 @@ export default {
           target = null
         }
         panes.push(pane)
+        this.currentTab = pane.name // select the tab corresponding to this pane
       }
 
       return panes


### PR DESCRIPTION
<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
1. 当`default-value`有初始值时，`tab-bar`默认选中的是第一项而非最后一项，体验不佳 #488 
2. 当更改了部分选项，但未保存直接点击取消后，`tab-bar`重新渲染有异常

### 主要改动
<!-- 列举具体改动点 -->
1. 在`pans`的计算过程中，保证`currentTab`更新为最后一个`pan`的`name`
2. 将用于强制重新渲染的`tabsTmpKey`挂在`tabs`上，使得取消操作时的整个`tabs`可被重新渲染

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->
无
<!-- PR 内容区 -->
