### PR TITLE
fix(build): resolved 'build components complete' log

### DIFF
--- a/build/rollup/build-component.rollup.js
+++ b/build/rollup/build-component.rollup.js
@@ -130,7 +130,8 @@ function compileVueAndReplace(filePath) {
       fs.writeFileAsync(jsFilePath, result)
       .then(() => fs.writeFileAsync(cssFilePath, styleContent))
       .then(() => {
-        return fs.unlinkAsync(filePath)
+        fs.unlinkAsync(filePath)
+        resolve()
       })
     })
   })


### PR DESCRIPTION

<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
打包 `components` 组件的时候，这行代码不会被触发 `resultLog('success', 'Build **Components** Complete!')`，因为方法 `compileVueAndReplace` 没有 `resolve`。
### 主要改动
<!-- 列举具体改动点 -->
无

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->
无

<!-- PR 内容区 -->
