### PR TITLE
feat(title-bar): add prop large-radius for "Popup" ed components

### DIFF
--- a/components/_style/mixin/theme.components.styl
+++ b/components/_style/mixin/theme.components.styl
@@ -285,10 +285,11 @@ picker-border-color = color-border-base
 picker-zindex = 1100
 
 /// popup
-popup-title-bar-bg = color-bg-base
+popup-title-bar-bg = color-bg-inverse
 popup-title-bar-height = 120px
 popup-title-bar-height-large = 180px
 popup-title-bar-radius = 8px
+popup-title-bar-radius-large = 40px
 popup-title-bar-font-size-button = font-caption-large
 popup-title-bar-font-weight-button = font-weight-medium
 popup-title-bar-font-size-title = 40px

--- a/components/action-sheet/README.en-US.md
+++ b/components/action-sheet/README.en-US.md
@@ -30,6 +30,7 @@ this.$actionsheet.create({ /* ... */ }) // Totally Import
 |default-index|default selected index|Boolean|0|-|
 |invalid-index|invalid index|Number| -1|-|
 |cancel-text|cancel text|String|-|-|
+|large-radius <sup class="version-after">2.4.0+</sup>|large radius|Boolean|`false`|-|
 
 #### ActionSheet Events
 

--- a/components/action-sheet/README.md
+++ b/components/action-sheet/README.md
@@ -29,6 +29,7 @@ this.$actionsheet.create({ /* ... */ }) // 全量引入
 |default-index|默认选中项| Boolean| `0`|-|
 |invalid-index|禁用选择项索引 |Number|`-1`|-|
 |cancel-text|取消按钮文案 |String |-|-|
+|large-radius <sup class="version-after">2.4.0+</sup>|大圆角模式|Boolean|`false`|-|
 
 #### ActionSheet Events
 

--- a/components/action-sheet/action-sheet.vue
+++ b/components/action-sheet/action-sheet.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="md-action-sheet">
     <md-popup
+      class="inner-popup large-radius"
       v-model="isActionSheetShow"
       position="bottom"
       prevent-scroll

--- a/components/cashier/README.en-US.md
+++ b/components/cashier/README.en-US.md
@@ -26,6 +26,7 @@ Vue.component(Cashier.name, Cashier)
 |channel-limit|show more payment channels button when the payment channels exceeds the limit|Number|`2`|-|
 |default-index|default selected index of payment channel |Number|`0`|-|
 |title|cashier title|String|`pay	`|-|
+|large-radius <sup class="version-after">2.4.0+</sup>|large radius of title bar|Boolean|`false`|-|
 |payment-title|payment amount title|String|`支付金额(元)`|support `html fragment`|
 |payment-amount|payment amount|String|`0.00`|support `html fragment`|
 |payment-describe|the description of payment amount |String|-|support `html fragment`|

--- a/components/cashier/README.md
+++ b/components/cashier/README.md
@@ -26,6 +26,7 @@ Vue.component(Cashier.name, Cashier)
 |channel-limit|支付渠道超出限制数目时展示更多支付渠道按钮|Number|`2`|-|
 |default-index|默认选中支付渠道索引|Number|`0`|-|
 |title|收银台弹窗标题|String|`支付`|-|
+|large-radius <sup class="version-after">2.4.0+</sup>|选择器标题栏大圆角模式|Boolean|`false`|-|
 |payment-title|支付金额标题|String|`支付金额(元)`|支持`html fragment`|
 |payment-amount|支付金额|String|`0.00`|支持`html fragment`|
 |payment-describe|支付金额说明|String|-|支持`html fragment`|

--- a/components/cashier/demo/cases/demo0.vue
+++ b/components/cashier/demo/cases/demo0.vue
@@ -33,6 +33,7 @@
       :channel-limit="2"
       :payment-amount="cashierAmount"
       payment-describe="关于支付金额的特殊说明"
+      large-radius
       @select="onCashierSelect"
       @pay="onCashierPay"
       @cancel="onCashierCancel"

--- a/components/cashier/demo/cases/demo1.vue
+++ b/components/cashier/demo/cases/demo1.vue
@@ -7,6 +7,7 @@
       :channels="cashierChannels"
       :payment-amount="cashierAmount"
       payment-describe="关于支付金额的特殊说明"
+      large-radius
       @show="onCashierShow"
       @select="onCashierSelect"
       @pay="onCashierPay"

--- a/components/cashier/index.vue
+++ b/components/cashier/index.vue
@@ -16,9 +16,7 @@
         :large-radius="largeRadius"
         only-close
         @cancel="$_onPopupCancel"
-      >
-        <md-icon name="close" size="lg" slot="cancel"></md-icon>
-      </md-popup-title-bar>
+      ></md-popup-title-bar>
       <div class="md-cashier-container">
         <slot name="header" :scene="scene"></slot>
 

--- a/components/cashier/index.vue
+++ b/components/cashier/index.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="md-cashier">
     <md-popup
+      class="inner-popup"
       v-model="isCashierShow"
       position="bottom"
       :mask-closable="false"
@@ -12,6 +13,8 @@
       <md-popup-title-bar
         :title="title"
         :describe="describe"
+        :large-radius="largeRadius"
+        only-close
         @cancel="$_onPopupCancel"
       >
         <md-icon name="close" size="lg" slot="cancel"></md-icon>

--- a/components/date-picker/README.en-US.md
+++ b/components/date-picker/README.en-US.md
@@ -36,7 +36,8 @@ Vue.component(DatePicker.name, DatePicker)
 |describe|description of date-picker|String|-|-|
 |ok-text|confirmation text|String|`confirm`|-| 
 |cancel-text|cancellation text|String|`cancel`|-| 
-|mask-closable|if popup can be closed through clicking mask|String|`true`|-|
+|large-radius <sup class="version-after">2.4.0+</sup>|large radius of title bar|Boolean|`false`|-|
+|mask-closable|picker will be closed when clicking mask|String|`true`|-|
 
 #### DatePicker Methods
 

--- a/components/date-picker/README.md
+++ b/components/date-picker/README.md
@@ -36,6 +36,7 @@ Vue.component(DatePicker.name, DatePicker)
 |describe|选择器描述|String|-|-|
 |ok-text|选择器确认文案|String|`确认`|-| 
 |cancel-text|选择器取消文案|String|`取消`|-| 
+|large-radius <sup class="version-after">2.4.0+</sup>|选择器标题栏大圆角模式|Boolean|`false`|-|
 |mask-closable|点击蒙层是否可关闭弹出层|Boolean|`true`|-|
 
 #### DatePicker Methods

--- a/components/date-picker/demo/cases/demo3.vue
+++ b/components/date-picker/demo/cases/demo3.vue
@@ -15,6 +15,7 @@
       v-model="isDatePickerShow"
       type="custom"
       title="选择出险时间"
+      large-radius
       :text-render="textRender"
       :custom-types="['yyyy', 'MM','dd', 'hh', 'mm']"
       :default-date="currentDate"

--- a/components/date-picker/index.vue
+++ b/components/date-picker/index.vue
@@ -11,6 +11,7 @@
       :describe="describe"
       :ok-text="okText"
       :cancel-text="cancelText"
+      :large-radius="largeRadius"
       :is-view="isView"
       :mask-closable="maskClosable"
       @initialed="$emit('initialed')"

--- a/components/picker/README.en-US.md
+++ b/components/picker/README.en-US.md
@@ -34,6 +34,8 @@ Vue.component(Picker.name, Picker)
 |describe|description of picker|String|-|-|
 |ok-text|confirmation text|String|`confirm`|-|
 |cancel-text|cancellation text|String|`cancel`|-|
+|large-radius <sup class="version-after">2.4.0+</sup>|large radius of title bar|Boolean|`false`|-|
+|mask-closable|picker will be closed when clicking mask|Boolean|`true`|-|
 
 #### Picker Methods
 

--- a/components/picker/README.md
+++ b/components/picker/README.md
@@ -34,6 +34,7 @@ Vue.component(Picker.name, Picker)
 |describe|选择器描述|String|-|-|
 |ok-text|选择器确认文案|String|`确认`|-|
 |cancel-text|选择器取消文案|String|`取消`|-|
+|large-radius <sup class="version-after">2.4.0+</sup>|选择器标题栏大圆角模式|Boolean|`false`|-|
 |mask-closable|点击蒙层是否可关闭弹出层|Boolean|`true`|-|
 
 #### Picker Methods

--- a/components/picker/demo/cases/demo2.vue
+++ b/components/picker/demo/cases/demo2.vue
@@ -18,6 +18,7 @@
       ref="picker0"
       v-model="isPickerShow0"
       :data="pickerData0"
+      large-radius
       @confirm="onPickerConfirm(0)"
       title="选择年份"
     ></md-picker>
@@ -27,6 +28,7 @@
       :data="pickerData1"
       :cols="3"
       is-cascade
+      large-radius
       title="选择省市区/县"
       @confirm="onPickerConfirm(1)"
     ></md-picker>

--- a/components/picker/index.vue
+++ b/components/picker/index.vue
@@ -34,6 +34,7 @@
           :describe="describe"
           :ok-text="okText"
           :cancel-text="cancelText"
+          :large-radius="largeRadius"
           @confirm="$_onPickerConfirm"
           @cancel="$_onPickerCancel"
         ></md-popup-title-bar>

--- a/components/picker/picker-column.vue
+++ b/components/picker/picker-column.vue
@@ -528,6 +528,7 @@ export default {
 .md-picker-column-list
   display flex
   height 100%
+  padding 0 picker-padding-h
 
 .md-picker-column-item
   position relative

--- a/components/popup/README.en-US.md
+++ b/components/popup/README.en-US.md
@@ -34,6 +34,8 @@ Vue.component(PopupTitleBar.name, PopupTitleBar)
 |describe|description of popup|String|-|-|
 |ok-text|confirmation text|String|-|no confirmation button if empty|
 |cancel-text|cancellation text|String|-|no cancellation button if empty|
+|large-radius|large radius|Boolean|`false`|-|
+|only-close|only right close button|Boolean|`false`|-|
 
 #### Popup Events
 

--- a/components/popup/README.en-US.md
+++ b/components/popup/README.en-US.md
@@ -36,6 +36,7 @@ Vue.component(PopupTitleBar.name, PopupTitleBar)
 |cancel-text|cancellation text|String|-|no cancellation button if empty|
 |large-radius|large radius|Boolean|`false`|-|
 |only-close|only right close button|Boolean|`false`|-|
+|title-align <sup class="version-after">2.4.0+</sup>|title and description position|String|`center`|note that `left` and `right` will hide the left and right buttons respectively|
 
 #### Popup Events
 

--- a/components/popup/README.md
+++ b/components/popup/README.md
@@ -35,6 +35,8 @@ Vue.component(PopupTitleBar.name, PopupTitleBar)
 |describe|描述|String|-|-|
 |ok-text|确认按钮文案|String|-|为空则没有确认按钮|
 |cancel-text|取消按钮文案|String|-|为空则没有取消按钮|
+|large-radius <sup class="version-after">2.4.0+</sup>|大圆角模式|Boolean|`false`|-|
+|only-close <sup class="version-after">2.4.0+</sup>|只有右侧关闭按钮|Boolean|`false`|-|
 
 #### Popup Events
 

--- a/components/popup/README.md
+++ b/components/popup/README.md
@@ -37,6 +37,7 @@ Vue.component(PopupTitleBar.name, PopupTitleBar)
 |cancel-text|取消按钮文案|String|-|为空则没有取消按钮|
 |large-radius <sup class="version-after">2.4.0+</sup>|大圆角模式|Boolean|`false`|-|
 |only-close <sup class="version-after">2.4.0+</sup>|只有右侧关闭按钮|Boolean|`false`|-|
+|title-align <sup class="version-after">2.4.0+</sup>|标题和描述位置|String|`center`|注意`left`和`right`时会分别隐藏左右两侧按钮|
 
 #### Popup Events
 

--- a/components/popup/demo/cases/demo0.vue
+++ b/components/popup/demo/cases/demo0.vue
@@ -17,6 +17,7 @@
         describe="Popup Description"
         ok-text="ok"
         cancel-text="cancel"
+        large-radius
         @confirm="hidePopUp('bottom')"
         @cancel="hidePopUp('bottom')"
       ></md-popup-title-bar>

--- a/components/popup/demo/cases/demo1.vue
+++ b/components/popup/demo/cases/demo1.vue
@@ -22,14 +22,30 @@
       :mask-closable="false"
     >
       <md-popup-title-bar
-        title="Prevent Mask Click"
-        ok-text="ok"
-        cancel-text="cancel"
+        only-close
+        large-radius
         @confirm="hidePopUp('mask')"
         @cancel="hidePopUp('mask')"
       ></md-popup-title-bar>
       <div class="md-example-popup md-example-popup-bottom">
-        Popup Bottom
+        <p>Recording</p>
+        <!-- By Sam Herbert (@sherb), for everyone. More @ http://goo.gl/7AJzbL -->
+        <svg width="55" height="80" viewBox="0 0 55 80" xmlns="http://www.w3.org/2000/svg" fill="#2f86f6">
+          <g transform="matrix(1 0 0 -1 0 80)">
+            <rect width="10" height="20" rx="3">
+              <animate attributeName="height" begin="0s" dur="4.3s" values="20;45;57;80;64;32;66;45;64;23;66;13;64;56;34;34;2;23;76;79;20" calcMode="linear" repeatCount="indefinite" />
+            </rect>
+            <rect x="15" width="10" height="80" rx="3">
+              <animate attributeName="height" begin="0s" dur="2s" values="80;55;33;5;75;23;73;33;12;14;60;80" calcMode="linear" repeatCount="indefinite" />
+            </rect>
+            <rect x="30" width="10" height="50" rx="3">
+              <animate attributeName="height" begin="0s" dur="1.4s" values="50;34;78;23;56;23;34;76;80;54;21;50" calcMode="linear" repeatCount="indefinite" />
+            </rect>
+            <rect x="45" width="10" height="30" rx="3">
+              <animate attributeName="height" begin="0s" dur="2s" values="30;45;13;80;56;72;45;76;34;23;67;30" calcMode="linear" repeatCount="indefinite" />
+            </rect>
+          </g>
+        </svg>
       </div>
     </md-popup>
   </div>
@@ -99,9 +115,12 @@ export default {
       transform translateY(-50%)
   .md-example-popup-bottom
     width 100%
-    padding: 50px 0
+    padding 0 0 150px
     p
-      line-height 50px
+      margin-bottom 100px
+      font-size 64px
+      font-weight 200
+      color #999
   .md-example-popup-left, .md-example-popup-right
     height 100%
     padding 0 150px

--- a/components/popup/demo/cases/demo1.vue
+++ b/components/popup/demo/cases/demo1.vue
@@ -1,5 +1,26 @@
 <template>
   <div class="md-example-child md-example-child-popup md-example-child-popup-2">
+    <md-button @click="showPopUp('align')">标题居左</md-button>
+    <md-popup
+      class="inner-popup"
+      v-model="isPopupShow.align"
+      position="bottom"
+    >
+      <md-popup-title-bar
+        only-close
+        large-radius
+        title="标题"
+        describe="title & description align left"
+        title-align="left"
+        @cancel="hidePopUp('align')"
+      ></md-popup-title-bar>
+      <div class="md-example-popup md-example-popup-align">
+        <md-scroll-view :scrolling-x="false">
+          <p>Scroll View</p>
+        </md-scroll-view>
+      </div>
+    </md-popup>
+
     <md-button @click="showPopUp('top')">无遮罩层</md-button>
     <md-popup
       v-model="isPopupShow.top"
@@ -51,19 +72,21 @@
   </div>
 </template>
 
-<script>import {Popup, PopupTitleBar, Button, Icon} from 'mand-mobile'
+<script>import {Popup, PopupTitleBar, ScrollView, Button, Icon} from 'mand-mobile'
 
 export default {
   name: 'popup-demo',
   /* DELETE */
   title: '其他配置',
   titleEnUS: 'Other configurations',
+  height: '500',
   /* DELETE */
   components: {
     [Popup.name]: Popup,
     [PopupTitleBar.name]: PopupTitleBar,
     [Button.name]: Button,
     [Icon.name]: Icon,
+    [ScrollView.name]: ScrollView,
   },
   data() {
     return {
@@ -99,9 +122,16 @@ export default {
     box-sizing border-box
     text-align center
     background-color #FFF
-  .md-example-popup-center
-    padding 50px
-    border-radius radius-normal
+  .md-example-popup-align
+    padding 0 40px
+    .md-scroll-view
+      height 500px
+      background #EEE
+      p
+        line-height 500px
+        font-size 64px
+        font-weight 200
+        color #999
   .md-example-popup-top
     width 100%
     height 75px

--- a/components/popup/index.vue
+++ b/components/popup/index.vue
@@ -4,6 +4,7 @@
     class="md-popup"
     :class="[
       hasMask ? 'with-mask' : '',
+      largeRadius ? 'large-radius' : '',
       position
     ]"
   >
@@ -104,6 +105,7 @@ export default {
       isPopupBoxShow: false,
       // transtion lock
       isAnimation: false,
+      largeRadius: false,
     }
   },
 
@@ -262,6 +264,8 @@ export default {
   &.inner-popup .md-popup-box
     background-color color-bg-inverse
     border-radius popup-title-bar-radius popup-title-bar-radius 0 0
+  &.large-radius.inner-popup .md-popup-box
+    border-radius popup-title-bar-radius-large popup-title-bar-radius-large 0 0
 
 .md-popup-mask
   absolute-pos()

--- a/components/popup/mixins/title-bar.js
+++ b/components/popup/mixins/title-bar.js
@@ -16,6 +16,10 @@ export default {
       type: String,
       default: '',
     },
+    titleAlign: {
+      type: String,
+      default: 'center',
+    },
     largeRadius: {
       type: Boolean,
       default: false,

--- a/components/popup/mixins/title-bar.js
+++ b/components/popup/mixins/title-bar.js
@@ -16,5 +16,13 @@ export default {
       type: String,
       default: '',
     },
+    largeRadius: {
+      type: Boolean,
+      default: false,
+    },
+    onlyClose: {
+      type: Boolean,
+      default: false,
+    },
   },
 }

--- a/components/popup/title-bar.vue
+++ b/components/popup/title-bar.vue
@@ -1,7 +1,10 @@
 <template>
   <div
     class="md-popup-title-bar"
-    :class="{large: !!describe, 'large-radius': largeRadius}"
+    :class="[
+      `title-align-${titleAlign}`,
+      ...{large: !!describe, 'large-radius': largeRadius}
+    ]"
     @touchmove="$_preventScroll"
   >
     <!-- Cancel -->
@@ -142,13 +145,26 @@ export default {
     height popup-title-bar-height-large
   &.large-radius
     border-radius popup-title-bar-radius-large popup-title-bar-radius-large 0 0
+  &.title-align-left
+    .title-bar-title
+      padding-left h-gap-sl
+      align-items flex-start
+    .title-bar-left
+      display none
+  &.title-align-right
+    .title-bar-title
+      padding-right h-gap-sl
+      align-items flex-end
+    .title-bar-right
+      display none
   &>div
     display flex
     float left
     height 100%
+    padding-top 60px
     flex-direction column
     align-items center
-    justify-content center
+    justify-content flex-start
     overflow hidden
     text-overflow ellipsis
     word-break break-word
@@ -160,15 +176,18 @@ export default {
     font-size popup-title-bar-font-size-button
     font-weight popup-title-bar-font-weight-button
     box-sizing border-box
+    line-height 1
   .title-bar-title
     width 100%
-    padding 0 20%
+    padding-left 20%
+    padding-right 20%
     box-sizing border-box
+    line-height 1
     p.title
       font-size popup-title-bar-font-size-title
       color popup-title-bar-color-title
     p.describe
-      margin-top 4px
+      margin-top 15px
       font-size popup-title-bar-font-size-describe
       color popup-title-bar-color-describe
   .title-bar-left

--- a/components/popup/title-bar.vue
+++ b/components/popup/title-bar.vue
@@ -1,23 +1,25 @@
 <template>
   <div
     class="md-popup-title-bar"
-    :class="{large: !!describe}"
+    :class="{large: !!describe, 'large-radius': largeRadius}"
     @touchmove="$_preventScroll"
   >
     <!-- Cancel -->
-    <div
-      class="title-bar-left md-popup-cancel"
-      v-if="cancelText"
-      v-html="cancelText"
-      @click="$emit('cancel')"
-    ></div>
-    <div
-      class="title-bar-left md-popup-cancel"
-      v-else-if="$slots.cancel"
-      @click="$emit('cancel')"
-    >
-      <slot name="cancel"></slot>
-    </div>
+    <template v-if="!onlyClose">
+      <div
+        class="title-bar-left md-popup-cancel"
+        v-if="cancelText"
+        v-html="cancelText"
+        @click="$emit('cancel')"
+      ></div>
+      <div
+        class="title-bar-left md-popup-cancel"
+        v-else-if="$slots.cancel"
+        @click="$emit('cancel')"
+      >
+        <slot name="cancel"></slot>
+      </div>
+    </template>
 
     <!-- Title -->
     <div
@@ -43,28 +45,43 @@
     </div>
 
     <!-- Ok -->
-    <div
-      class="title-bar-right md-popup-confirm"
-      v-if="okText"
-      v-html="okText"
-      @click="$emit('confirm')"
-    ></div>
-    <div
-      class="title-bar-right md-popup-confirm"
-      v-else-if="$slots.confirm"
-      @click="$emit('confirm')"
-    >
-      <slot name="confirm"></slot>
-    </div>
+    <template v-if="!onlyClose">
+      <div
+        class="title-bar-right md-popup-confirm"
+        v-if="okText"
+        v-html="okText"
+        @click="$emit('confirm')"
+      ></div>
+      <div
+        class="title-bar-right md-popup-confirm"
+        v-else-if="$slots.confirm"
+        @click="$emit('confirm')"
+      >
+        <slot name="confirm"></slot>
+      </div>
+    </template>
+    <template v-if="onlyClose">
+      <div
+        class="title-bar-right md-popup-close"
+        @click="$emit('cancel')"
+      >
+        <md-icon name="close" size="lg"></md-icon>
+      </div>
+    </template>
   </div>
 </template>
 
 <script>import titleBarMixin from './mixins/title-bar'
+import Icon from '../icon'
 
 export default {
   name: 'md-popup-title-bar',
 
   mixins: [titleBarMixin],
+
+  components: {
+    [Icon.name]: Icon,
+  },
 
   props: {
     // Mixin Props
@@ -84,6 +101,23 @@ export default {
     //   type: String,
     //   default: '',
     // },
+    // largeRadius: {
+    //   type: Boolean,
+    //   default: false,
+    // },
+    // onlyClose: {
+    //   type: Boolean,
+    //   default: false,
+    // },
+  },
+
+  watch: {
+    largeRadius: {
+      handler(val) {
+        this.$parent.largeRadius = val
+      },
+      immediate: true,
+    },
   },
 
   methods: {
@@ -106,6 +140,8 @@ export default {
   overflow hidden
   &.large
     height popup-title-bar-height-large
+  &.large-radius
+    border-radius popup-title-bar-radius-large popup-title-bar-radius-large 0 0
   &>div
     display flex
     float left
@@ -137,8 +173,18 @@ export default {
       color popup-title-bar-color-describe
   .title-bar-left
     left 0
-    color popup-title-bar-color-button-left
+    padding-left h-gap-sl
+    align-items flex-start
   .title-bar-right
     right 0
+    padding-right h-gap-sl
+    align-items flex-end
+  .md-popup-cancel
+    color popup-title-bar-color-button-left
+  .md-popup-confirm
     color popup-title-bar-color-button-right
+  .md-popup-close
+    padding-top h-gap-sl
+    color popup-title-bar-color-button-left
+    justify-content flex-start
 </style>

--- a/components/selector/README.en-US.md
+++ b/components/selector/README.en-US.md
@@ -24,13 +24,13 @@ Vue.component(Selector.name, Selector)
 |----|-----|------|------|------|
 |v-model|display selector or not|Boolean|false|-|
 |data|data source|Array<{value,text,disabled,...}>|`[]`|`text` can be a `html` fragment|
-|default-value|the value of initially selected item|any|-|when `multi` is `true`, `default-value` should be `array`<sup class="version-after">2.3.0+</sup>|
+|default-value <sup class="version-after">2.3.0+</sup>|the value of initially selected item|any|-|when `multi` is `true`, `default-value` should be `array`|
 |title|title of selector|String|-|-|
 |describe|description of selector|String|-|-|
 |ok-text|confirmation text|String|-|if empty, it will be `confirmed mode`, that is, click to select directly|
 |cancel-text|cancellation text|String|`cancel`|-|
-|large-radius|large radius of title bar|Boolean|`false`|-|
-|hide-title-bar|hide title bar|Boolean|`false`|-|
+|large-radius <sup class="version-after">2.4.0+</sup>|large radius of title bar|Boolean|`false`|-|
+|hide-title-bar <sup class="version-after">2.4.0+</sup>|hide title bar|Boolean|`false`|-|
 |mask-closable|if the popup will be closed when clicking mask|Boolean|`true`|-|
 |is-check|has a `check` icon or not|Boolean|`false`|only for `confirmed mode`|
 |max-height|the maximum height of selectable area|Number/String|`auto`|-|

--- a/components/selector/README.en-US.md
+++ b/components/selector/README.en-US.md
@@ -29,6 +29,8 @@ Vue.component(Selector.name, Selector)
 |describe|description of selector|String|-|-|
 |ok-text|confirmation text|String|-|if empty, it will be `confirmed mode`, that is, click to select directly|
 |cancel-text|cancellation text|String|`cancel`|-|
+|large-radius|large radius of title bar|Boolean|`false`|-|
+|hide-title-bar|hide title bar|Boolean|`false`|-|
 |mask-closable|if the popup will be closed when clicking mask|Boolean|`true`|-|
 |is-check|has a `check` icon or not|Boolean|`false`|only for `confirmed mode`|
 |max-height|the maximum height of selectable area|Number/String|`auto`|-|
@@ -60,10 +62,21 @@ Show selector
 Hide selector
 
 #### Selector Slots
+
+##### default
+
 ```html
 <md-selector>
-  <template slot-scope="{ option }">
+  <template slot-scope="{ option, index, selected }">
     <div class="md-selector-custom-title">Hello, {{ option.text }}</div>
   </template>
 </md-selector>
 ```
+
+##### header
+
+header slot     
+
+##### footer
+
+footer slot     

--- a/components/selector/README.md
+++ b/components/selector/README.md
@@ -24,13 +24,13 @@ Vue.component(Selector.name, Selector)
 |----|-----|------|------|------|
 |v-model|选择器是否可见|Boolean|false|-|
 |data|数据源|Array<{value,text,disabled,...}>|`[]`|`text`可为`html`片段|
-|default-value|选择器初始选中项的值|any|-|`multi`为`true`时，`default-value`应该传数组<sup class="version-after">2.3.0+</sup>|
+|default-value <sup class="version-after">2.3.0+</sup>|选择器初始选中项的值|any|-|`multi`为`true`时，`default-value`应该传数组|
 |title|选择器标题|String|-|-|
 |describe|选择器描述|String|-|-|
 |ok-text|选择器确认文案|String|-|若为空则为`确认模式`，即点击选项直接选择|
 |cancel-text|选择器取消文案|String|`取消`|-|
-|large-radius|选择器标题栏大圆角模式|Boolean|`false`|-|
-|hide-title-bar|隐藏选择器标题栏|Boolean|`false`|-|
+|large-radius <sup class="version-after">2.4.0+</sup>|选择器标题栏大圆角模式|Boolean|`false`|-|
+|hide-title-bar <sup class="version-after">2.4.0+</sup>|隐藏选择器标题栏|Boolean|`false`|-|
 |mask-closable|点击蒙层是否可关闭弹出层|Boolean|`true`|-|
 |is-check|是否有`check`图标|Boolean|`false`|仅`确认模式`|
 |max-height|选择器内容区域最高高度, 超出后可滚动|Number/String|`auto`|-|

--- a/components/selector/README.md
+++ b/components/selector/README.md
@@ -29,6 +29,8 @@ Vue.component(Selector.name, Selector)
 |describe|选择器描述|String|-|-|
 |ok-text|选择器确认文案|String|-|若为空则为`确认模式`，即点击选项直接选择|
 |cancel-text|选择器取消文案|String|`取消`|-|
+|large-radius|选择器标题栏大圆角模式|Boolean|`false`|-|
+|hide-title-bar|隐藏选择器标题栏|Boolean|`false`|-|
 |mask-closable|点击蒙层是否可关闭弹出层|Boolean|`true`|-|
 |is-check|是否有`check`图标|Boolean|`false`|仅`确认模式`|
 |max-height|选择器内容区域最高高度, 超出后可滚动|Number/String|`auto`|-|
@@ -59,10 +61,21 @@ Vue.component(Selector.name, Selector)
 选择器隐藏事件
 
 #### Selector Slots
+
+##### default
+
 ```html
 <md-selector>
-  <template slot-scope="{ option }">
+  <template slot-scope="{ option, index, selected }">
     <div class="md-selector-custom-title">Hello, {{ option.text }}</div>
   </template>
 </md-selector>
 ```
+
+##### header
+
+顶部插槽        
+
+##### footer
+
+底部插槽      

--- a/components/selector/demo/cases/demo0.vue
+++ b/components/selector/demo/cases/demo0.vue
@@ -15,6 +15,7 @@
       :data="data[0]"
       max-height="320px"
       title="普通模式"
+      large-radius
       @choose="onSelectorChoose"
     ></md-selector>
   </div>

--- a/components/selector/demo/cases/demo1.vue
+++ b/components/selector/demo/cases/demo1.vue
@@ -12,12 +12,30 @@
     <md-selector
       v-model="isSelectorShow"
       :data="data[0]"
-      title="自定义选项"
+      hide-title-bar
+      large-radius
+      is-check
+      iconSize="lg"
       @choose="onSelectorChoose"
     >
-      <template slot-scope="{ option }">
-        <div class="md-selector-custom-brief">{{ option.text }}使用slot-scope</div>
+      <div class="selector-header" slot="header">
+        Header Slot
+      </div>
+      <template slot-scope="{ option, index, selected }">
+        <!-- <div class="md-selector-custom-brief">{{ option.text }}使用slot-scope</div> -->
+        <div class="selector-item-body" :class="{disabled: option.disabled, selected}">
+          <div class="selector-item-left">
+            <span class="holder" v-text="option.value"></span>
+          </div>
+          <div class="selector-item-content">
+            <p class="selector-item-title" v-text="option.text"></p>
+            <p class="selector-item-brief" v-text="`${option.describe}-${index}`"></p>
+          </div>
+        </div>
       </template>
+      <div class="selector-footer" slot="footer">
+        Footer Slot
+      </div>
     </md-selector>
   </div>
 </template>
@@ -42,20 +60,25 @@ export default {
       data: [
         [
           {
-            value: '1',
+            value: 'A',
             text: '选项一',
+            describe: '使用slot-scope',
           },
           {
-            value: '2',
+            value: 'B',
             text: '选项二',
+            describe: '使用slot-scope',
           },
           {
-            value: '3',
+            value: 'C',
             text: '选项三',
+            describe: '使用slot-scope',
+            disabled: true,
           },
           {
-            value: '4',
+            value: 'D',
             text: '选项四',
+            describe: '使用slot-scope',
           },
         ],
       ],
@@ -75,7 +98,42 @@ export default {
 
 <style lang="stylus">
 .md-example-child-selector-1
-  .md-selector-custom-brief
-    font-size 20px
-    color #999
+  .selector-header, .selector-footer
+    padding 15px 40px
+    font-size 16px
+    color #ccc
+  .selector-item-body
+    display flex
+    align-items center
+    &.selected
+      .selector-item-content
+        color #2f86f6
+    &.disabled
+      opacity .3
+    .selector-item-left
+      flex-shrink 0
+      margin-right 32px
+      .holder
+        display block
+        width 88px
+        height 88px
+        border-radius 44px
+        background-color #e6e6e6
+        font-size 32px
+        font-weight 500
+        color #2f86f6
+        text-align center
+        line-height 88px
+    .selector-item-content
+      flex 1
+      color #111a34
+      font-size 32px
+      line-height 1.2
+      .selector-item-title
+        line-height 1.2
+      .selector-item-brief
+        color #858b9c
+        font-size 24px
+        line-height 1.4
+        margin-top 8px
 </style>

--- a/components/selector/demo/cases/demo2.vue
+++ b/components/selector/demo/cases/demo2.vue
@@ -15,6 +15,7 @@
       min-height="320px"
       title="确认模式"
       okText="确认"
+      large-radius
       @confirm="onSelectorConfirm"
     ></md-selector>
   </div>

--- a/components/selector/demo/cases/demo3.vue
+++ b/components/selector/demo/cases/demo3.vue
@@ -15,6 +15,7 @@
       min-height="320px"
       okText="确认"
       cancelText="取消"
+      large-radius
       @confirm="onSelectorConfirm"
       is-check
     ></md-selector>

--- a/components/selector/demo/cases/demo4.vue
+++ b/components/selector/demo/cases/demo4.vue
@@ -16,6 +16,7 @@
       min-height="320px"
       okText="确定"
       cancelText="取消"
+      large-radius
       @confirm="onSelectorConfirm"
       multi
     ></md-selector>

--- a/components/selector/index.vue
+++ b/components/selector/index.vue
@@ -16,23 +16,17 @@
       @maskClick="$_onSelectorCancel"
     >
       <md-popup-title-bar
+        v-show="!hideTitleBar || isNeedConfirm"
         :title="title"
         :describe="describe"
         :ok-text="okText"
         :cancel-text="cancelText"
+        :large-radius="largeRadius"
+        :only-close="!isCheck && !isNeedConfirm && !cancelText"
         @confirm="$_onSelectorConfirm"
         @cancel="$_onSelectorCancel"
-      >
-        <md-icon
-          v-if="!isCheck && !isNeedConfirm && !cancelText"
-          name="close"
-          size="lg"
-          slot="cancel"
-        ></md-icon>
-      </md-popup-title-bar>
-      <div
-        class="md-selector-container"
-      >
+      ></md-popup-title-bar>
+      <div class="md-selector-container">
         <md-scroll-view
           ref="scroll"
           :scrolling-x="false"
@@ -41,6 +35,7 @@
             minHeight: `${minHeight}`
           }"
         >
+          <slot name="header"></slot>
           <!-- audio-list with single select -->
           <template v-if="!multi">
             <md-radio-list
@@ -58,8 +53,8 @@
               :icon-svg="iconSvg"
               @change="$_onSelectorChoose"
             >
-              <template slot-scope="{ option }">
-                <slot :option="option"></slot>
+              <template slot-scope="{ option, index, selected }">
+                <slot :option="option" :index="index" :selected="selected"></slot>
               </template>
             </md-radio-list>
           </template>
@@ -79,11 +74,12 @@
               :icon-size="iconSize"
               :icon-svg="iconSvg"
             >
-              <template slot-scope="{ option }">
-                <slot :option="option"></slot>
+              <template slot-scope="{ option, index, selected }">
+                <slot :option="option" :index="index" :selected="selected"></slot>
               </template>
             </md-check-list>
           </template>
+          <slot name="footer"></slot>
         </md-scroll-view>
       </div>
     </md-popup>
@@ -145,6 +141,10 @@ export default {
       default: 'right',
     },
     multi: {
+      type: Boolean,
+      default: false,
+    },
+    hideTitleBar: {
       type: Boolean,
       default: false,
     },
@@ -294,10 +294,9 @@ export default {
 .md-selector
   .md-popup
     z-index selector-zindex
-  .md-popup-title-bar .md-popup-cancel
-    .md-icon
-      align-self flex-start
-      margin-left h-gap-lg
+  // .md-popup-title-bar .md-popup-cancel
+  //   .md-icon
+  //     align-self flex-start
   .md-radio-item
     padding-left h-gap-sl
     padding-right h-gap-sl

--- a/components/selector/test/__snapshots__/demo.spec.js.snap
+++ b/components/selector/test/__snapshots__/demo.spec.js.snap
@@ -2,17 +2,34 @@
 
 exports[`Selector - Demo Check mode 1`] = `
 <div class="md-example-child md-example-child-selector md-example-child-selector-3">
+  <fieldset class="md-field">
+    <!---->
+    <div class="md-field-content">
+      <div class="md-field-item">
+        <div class="md-field-item-content"><label class="md-field-item-title">Check模式</label>
+          <!---->
+          <div class="md-field-item-control">
+            <!---->
+          </div>
+          <div class="md-field-item-right"> <i class="md-icon icon-font md-icon-arrow-right arrow-right md" style="color:;"></i></div>
+        </div>
+        <!---->
+      </div>
+    </div>
+    <!---->
+  </fieldset>
   <div class="md-selector is-check">
     <div class="md-popup inner-popup with-mask bottom" style="display:none;">
       <div name="md-mask-fade" class="md-popup-mask" style="display:none;"></div>
       <div name="md-slide-up" class="md-popup-box md-slide-up" style="display:none;">
-        <div class="md-popup-title-bar">
+        <div class="md-popup-title-bar large-radius">
           <div class="title-bar-left md-popup-cancel">取消</div>
           <div class="title-bar-title">
             <p class="title">Check模式</p>
             <!---->
           </div>
           <div class="title-bar-right md-popup-confirm">确认</div>
+          <!---->
         </div>
         <div class="md-selector-container">
           <div class="md-scroll-view" style="max-height:auto;min-height:320px;">
@@ -52,15 +69,15 @@ exports[`Selector - Demo Check mode 1`] = `
                   </div>
                   <!---->
                 </div>
-                <div class="md-cell-item md-radio-item">
+                <div class="md-cell-item md-radio-item is-disabled">
                   <div class="md-cell-item-body">
                     <!---->
                     <div class="md-cell-item-content">
                       <p class="md-cell-item-title">选项三</p>
                       <!---->
                     </div>
-                    <div class="md-cell-item-right"><label class="md-radio">
-                        <div class="md-radio-icon"><i class="md-icon icon-font md-icon-check check md" style="color:;"></i></div>
+                    <div class="md-cell-item-right"><label class="md-radio is-disabled">
+                        <div class="md-radio-icon"><i class="md-icon icon-font md-icon-check-disabled check-disabled md" style="color:;"></i></div>
                         <!---->
                       </label>
                       <!---->
@@ -99,17 +116,34 @@ exports[`Selector - Demo Check mode 1`] = `
 
 exports[`Selector - Demo Confirmed mode 1`] = `
 <div class="md-example-child md-example-child-selector md-example-child-selector-2">
+  <fieldset class="md-field">
+    <!---->
+    <div class="md-field-content">
+      <div class="md-field-item is-solid">
+        <div class="md-field-item-content"><label class="md-field-item-title">确认模式</label>
+          <!---->
+          <div class="md-field-item-control">
+            <!---->
+          </div>
+          <div class="md-field-item-right"> <i class="md-icon icon-font md-icon-arrow-right arrow-right md" style="color:;"></i></div>
+        </div>
+        <!---->
+      </div>
+    </div>
+    <!---->
+  </fieldset>
   <div class="md-selector is-normal">
     <div class="md-popup inner-popup with-mask bottom" style="display:none;">
       <div name="md-mask-fade" class="md-popup-mask" style="display:none;"></div>
       <div name="md-slide-up" class="md-popup-box md-slide-up" style="display:none;">
-        <div class="md-popup-title-bar">
+        <div class="md-popup-title-bar large-radius">
           <div class="title-bar-left md-popup-cancel">取消</div>
           <div class="title-bar-title">
             <p class="title">确认模式</p>
             <!---->
           </div>
           <div class="title-bar-right md-popup-confirm">确认</div>
+          <!---->
         </div>
         <div class="md-selector-container">
           <div class="md-scroll-view" style="max-height:auto;min-height:320px;">
@@ -196,16 +230,30 @@ exports[`Selector - Demo Confirmed mode 1`] = `
 
 exports[`Selector - Demo Custom options 1`] = `
 <div class="md-example-child md-example-child-selector md-example-child-selector-1">
-  <div class="md-selector is-normal">
+  <fieldset class="md-field">
+    <!---->
+    <div class="md-field-content">
+      <div class="md-field-item is-solid">
+        <div class="md-field-item-content"><label class="md-field-item-title">自定义</label>
+          <!---->
+          <div class="md-field-item-control">
+            <!---->
+          </div>
+          <div class="md-field-item-right"> <i class="md-icon icon-font md-icon-arrow-right arrow-right md" style="color:;"></i></div>
+        </div>
+        <!---->
+      </div>
+    </div>
+    <!---->
+  </fieldset>
+  <div class="md-selector is-check">
     <div class="md-popup inner-popup with-mask bottom" style="display:none;">
       <div name="md-mask-fade" class="md-popup-mask" style="display:none;"></div>
       <div name="md-slide-up" class="md-popup-box md-slide-up" style="display:none;">
-        <div class="md-popup-title-bar">
-          <div class="title-bar-left md-popup-cancel"><i class="md-icon icon-font md-icon-close close lg" style="color:;"></i></div>
-          <div class="title-bar-title">
-            <p class="title">自定义选项</p>
-            <!---->
-          </div>
+        <div class="md-popup-title-bar large-radius" style="display:none;">
+          <!---->
+          <div class="title-bar-title"></div>
+          <!---->
           <!---->
         </div>
         <div class="md-selector-container">
@@ -213,6 +261,9 @@ exports[`Selector - Demo Custom options 1`] = `
             <!---->
             <div class="scroll-view-container">
               <!---->
+              <div class="selector-header">
+                Header Slot
+              </div>
               <div class="md-radio-list md-selector-list">
                 <div class="md-cell-item md-radio-item">
                   <div class="md-cell-item-body">
@@ -220,10 +271,16 @@ exports[`Selector - Demo Custom options 1`] = `
                     <div class="md-cell-item-content">
                       <!---->
                       <!---->
-                      <div class="md-selector-custom-brief">选项一使用slot-scope</div>
+                      <div class="selector-item-body">
+                        <div class="selector-item-left"><span class="holder">A</span></div>
+                        <div class="selector-item-content">
+                          <p class="selector-item-title">选项一</p>
+                          <p class="selector-item-brief">使用slot-scope-0</p>
+                        </div>
+                      </div>
                     </div>
                     <div class="md-cell-item-right"><label class="md-radio">
-                        <div class="md-radio-icon"><i class="md-icon icon-font md-icon-check check md" style="color:;"></i></div>
+                        <div class="md-radio-icon"><i class="md-icon icon-font md-icon-check check lg" style="color:;"></i></div>
                         <!---->
                       </label>
                       <!---->
@@ -237,10 +294,16 @@ exports[`Selector - Demo Custom options 1`] = `
                     <div class="md-cell-item-content">
                       <!---->
                       <!---->
-                      <div class="md-selector-custom-brief">选项二使用slot-scope</div>
+                      <div class="selector-item-body">
+                        <div class="selector-item-left"><span class="holder">B</span></div>
+                        <div class="selector-item-content">
+                          <p class="selector-item-title">选项二</p>
+                          <p class="selector-item-brief">使用slot-scope-1</p>
+                        </div>
+                      </div>
                     </div>
                     <div class="md-cell-item-right"><label class="md-radio">
-                        <div class="md-radio-icon"><i class="md-icon icon-font md-icon-check check md" style="color:;"></i></div>
+                        <div class="md-radio-icon"><i class="md-icon icon-font md-icon-check check lg" style="color:;"></i></div>
                         <!---->
                       </label>
                       <!---->
@@ -248,16 +311,22 @@ exports[`Selector - Demo Custom options 1`] = `
                   </div>
                   <!---->
                 </div>
-                <div class="md-cell-item md-radio-item">
+                <div class="md-cell-item md-radio-item is-disabled">
                   <div class="md-cell-item-body">
                     <!---->
                     <div class="md-cell-item-content">
                       <!---->
                       <!---->
-                      <div class="md-selector-custom-brief">选项三使用slot-scope</div>
+                      <div class="selector-item-body disabled">
+                        <div class="selector-item-left"><span class="holder">C</span></div>
+                        <div class="selector-item-content">
+                          <p class="selector-item-title">选项三</p>
+                          <p class="selector-item-brief">使用slot-scope-2</p>
+                        </div>
+                      </div>
                     </div>
-                    <div class="md-cell-item-right"><label class="md-radio">
-                        <div class="md-radio-icon"><i class="md-icon icon-font md-icon-check check md" style="color:;"></i></div>
+                    <div class="md-cell-item-right"><label class="md-radio is-disabled">
+                        <div class="md-radio-icon"><i class="md-icon icon-font md-icon-check-disabled check-disabled lg" style="color:;"></i></div>
                         <!---->
                       </label>
                       <!---->
@@ -271,10 +340,16 @@ exports[`Selector - Demo Custom options 1`] = `
                     <div class="md-cell-item-content">
                       <!---->
                       <!---->
-                      <div class="md-selector-custom-brief">选项四使用slot-scope</div>
+                      <div class="selector-item-body">
+                        <div class="selector-item-left"><span class="holder">D</span></div>
+                        <div class="selector-item-content">
+                          <p class="selector-item-title">选项四</p>
+                          <p class="selector-item-brief">使用slot-scope-3</p>
+                        </div>
+                      </div>
                     </div>
                     <div class="md-cell-item-right"><label class="md-radio">
-                        <div class="md-radio-icon"><i class="md-icon icon-font md-icon-check check md" style="color:;"></i></div>
+                        <div class="md-radio-icon"><i class="md-icon icon-font md-icon-check check lg" style="color:;"></i></div>
                         <!---->
                       </label>
                       <!---->
@@ -283,6 +358,9 @@ exports[`Selector - Demo Custom options 1`] = `
                   <!---->
                 </div>
                 <!---->
+              </div>
+              <div class="selector-footer">
+                Footer Slot
               </div>
               <!---->
             </div>
@@ -297,17 +375,32 @@ exports[`Selector - Demo Custom options 1`] = `
 
 exports[`Selector - Demo Multi mode 1`] = `
 <div class="md-example-child md-example-child-selector md-example-child-selector-4">
+  <fieldset class="md-field">
+    <!---->
+    <div class="md-field-content">
+      <div class="md-field-item">
+        <div class="md-field-item-content"><label class="md-field-item-title">多选模式</label>
+          <!---->
+          <div class="md-field-item-control">1</div>
+          <div class="md-field-item-right"> <i class="md-icon icon-font md-icon-arrow-right arrow-right md" style="color:;"></i></div>
+        </div>
+        <!---->
+      </div>
+    </div>
+    <!---->
+  </fieldset>
   <div class="md-selector is-normal">
     <div class="md-popup inner-popup with-mask bottom" style="display:none;">
       <div name="md-mask-fade" class="md-popup-mask" style="display:none;"></div>
       <div name="md-slide-up" class="md-popup-box md-slide-up" style="display:none;">
-        <div class="md-popup-title-bar">
+        <div class="md-popup-title-bar large-radius">
           <div class="title-bar-left md-popup-cancel">取消</div>
           <div class="title-bar-title">
             <p class="title">多选模式</p>
             <!---->
           </div>
           <div class="title-bar-right md-popup-confirm">确定</div>
+          <!---->
         </div>
         <div class="md-selector-container">
           <div class="md-scroll-view" style="max-height:auto;min-height:320px;">
@@ -393,17 +486,32 @@ exports[`Selector - Demo Multi mode 1`] = `
 
 exports[`Selector - Demo No need to confirm 1`] = `
 <div class="md-example-child md-example-child-selector md-example-child-selector-0">
+  <fieldset class="md-field">
+    <!---->
+    <div class="md-field-content">
+      <div class="md-field-item is-solid">
+        <div class="md-field-item-content"><label class="md-field-item-title">普通模式</label>
+          <!---->
+          <div class="md-field-item-control">选项二</div>
+          <div class="md-field-item-right"> <i class="md-icon icon-font md-icon-arrow-right arrow-right md" style="color:;"></i></div>
+        </div>
+        <!---->
+      </div>
+    </div>
+    <!---->
+  </fieldset>
   <div class="md-selector is-normal">
     <div class="md-popup inner-popup with-mask bottom" style="display:none;">
       <div name="md-mask-fade" class="md-popup-mask" style="display:none;"></div>
       <div name="md-slide-up" class="md-popup-box md-slide-up" style="display:none;">
-        <div class="md-popup-title-bar">
-          <div class="title-bar-left md-popup-cancel"><i class="md-icon icon-font md-icon-close close lg" style="color:;"></i></div>
+        <div class="md-popup-title-bar large-radius">
+          <!---->
           <div class="title-bar-title">
             <p class="title">普通模式</p>
             <!---->
           </div>
           <!---->
+          <div class="title-bar-right md-popup-close"><i class="md-icon icon-font md-icon-close close lg" style="color:;"></i></div>
         </div>
         <div class="md-selector-container">
           <div class="md-scroll-view" style="max-height:320px;min-height:auto;">

--- a/components/selector/test/cases/demo0.vue
+++ b/components/selector/test/cases/demo0.vue
@@ -1,21 +1,39 @@
 <template>
   <div class="md-example-child md-example-child-selector md-example-child-selector-0">
+    <md-field>
+      <md-field-item
+        title="普通模式"
+        :content="selectorValue"
+        @click="showSelector"
+        arrow
+        solid
+      />
+    </md-field>
     <md-selector
-      value
+      v-model="isSelectorShow"
       default-value="2"
       :data="data[0]"
       max-height="320px"
       title="普通模式"
+      large-radius
+      @choose="onSelectorChoose"
     ></md-selector>
   </div>
 </template>
 
-<script>import {Selector} from 'mand-mobile'
+<script>import {Selector, Field, FieldItem} from 'mand-mobile'
 
 export default {
   name: 'selector-demo',
+  /* DELETE */
+  title: '无需确认',
+  titleEnUS: 'No need to confirm',
+  height: 500,
+  /* DELETE */
   components: {
     [Selector.name]: Selector,
+    [Field.name]: Field,
+    [FieldItem.name]: FieldItem,
   },
   data() {
     return {
@@ -66,6 +84,14 @@ export default {
       ],
       selectorValue: '选项二',
     }
+  },
+  methods: {
+    showSelector() {
+      this.isSelectorShow = true
+    },
+    onSelectorChoose({text}) {
+      this.selectorValue = text
+    },
   },
 }
 </script>

--- a/components/selector/test/cases/demo1.vue
+++ b/components/selector/test/cases/demo1.vue
@@ -1,23 +1,58 @@
 <template>
   <div class="md-example-child md-example-child-selector md-example-child-selector-1">
+    <md-field>
+      <md-field-item
+        title="自定义"
+        :content="selectorValue"
+        @click="showSelector"
+        arrow
+        solid
+      />
+    </md-field>
     <md-selector
-      value
+      v-model="isSelectorShow"
       :data="data[0]"
-      title="自定义选项"
+      hide-title-bar
+      large-radius
+      is-check
+      iconSize="lg"
+      @choose="onSelectorChoose"
     >
-      <template slot-scope="{ option }">
-        <div class="md-selector-custom-brief">{{ option.text }}使用slot-scope</div>
+      <div class="selector-header" slot="header">
+        Header Slot
+      </div>
+      <template slot-scope="{ option, index, selected }">
+        <!-- <div class="md-selector-custom-brief">{{ option.text }}使用slot-scope</div> -->
+        <div class="selector-item-body" :class="{disabled: option.disabled, selected}">
+          <div class="selector-item-left">
+            <span class="holder" v-text="option.value"></span>
+          </div>
+          <div class="selector-item-content">
+            <p class="selector-item-title" v-text="option.text"></p>
+            <p class="selector-item-brief" v-text="`${option.describe}-${index}`"></p>
+          </div>
+        </div>
       </template>
+      <div class="selector-footer" slot="footer">
+        Footer Slot
+      </div>
     </md-selector>
   </div>
 </template>
 
-<script>import {Selector} from 'mand-mobile'
+<script>import {Selector, Field, FieldItem} from 'mand-mobile'
 
 export default {
   name: 'selector-demo',
+  /* DELETE */
+  title: '自定义选项',
+  titleEnUS: 'Custom options',
+  height: 400,
+  /* DELETE */
   components: {
     [Selector.name]: Selector,
+    [Field.name]: Field,
+    [FieldItem.name]: FieldItem,
   },
   data() {
     return {
@@ -25,32 +60,80 @@ export default {
       data: [
         [
           {
-            value: '1',
+            value: 'A',
             text: '选项一',
+            describe: '使用slot-scope',
           },
           {
-            value: '2',
+            value: 'B',
             text: '选项二',
+            describe: '使用slot-scope',
           },
           {
-            value: '3',
+            value: 'C',
             text: '选项三',
+            describe: '使用slot-scope',
+            disabled: true,
           },
           {
-            value: '4',
+            value: 'D',
             text: '选项四',
+            describe: '使用slot-scope',
           },
         ],
       ],
       selectorValue: '',
     }
   },
+  methods: {
+    showSelector() {
+      this.isSelectorShow = true
+    },
+    onSelectorChoose({text}) {
+      this.selectorValue = text
+    },
+  },
 }
 </script>
 
 <style lang="stylus">
 .md-example-child-selector-1
-  .md-selector-custom-brief
-    font-size 20px
-    color #999
+  .selector-header, .selector-footer
+    padding 15px 40px
+    font-size 16px
+    color #ccc
+  .selector-item-body
+    display flex
+    align-items center
+    &.selected
+      .selector-item-content
+        color #2f86f6
+    &.disabled
+      opacity .3
+    .selector-item-left
+      flex-shrink 0
+      margin-right 32px
+      .holder
+        display block
+        width 88px
+        height 88px
+        border-radius 44px
+        background-color #e6e6e6
+        font-size 32px
+        font-weight 500
+        color #2f86f6
+        text-align center
+        line-height 88px
+    .selector-item-content
+      flex 1
+      color #111a34
+      font-size 32px
+      line-height 1.2
+      .selector-item-title
+        line-height 1.2
+      .selector-item-brief
+        color #858b9c
+        font-size 24px
+        line-height 1.4
+        margin-top 8px
 </style>

--- a/components/selector/test/cases/demo2.vue
+++ b/components/selector/test/cases/demo2.vue
@@ -1,21 +1,39 @@
 <template>
   <div class="md-example-child md-example-child-selector md-example-child-selector-2">
+    <md-field>
+      <md-field-item
+        title="确认模式"
+        :content="selectorValue"
+        @click="showSelector"
+        arrow
+        solid
+      />
+    </md-field>
     <md-selector
-      value
+      v-model="isSelectorShow"
       :data="data[0]"
       min-height="320px"
       title="确认模式"
       okText="确认"
+      large-radius
+      @confirm="onSelectorConfirm"
     ></md-selector>
   </div>
 </template>
 
-<script>import {Selector} from 'mand-mobile'
+<script>import {Selector, Field, FieldItem} from 'mand-mobile'
 
 export default {
   name: 'selector-demo',
+  /* DELETE */
+  title: '确认模式',
+  titleEnUS: 'Confirmed mode',
+  height: 500,
+  /* DELETE */
   components: {
     [Selector.name]: Selector,
+    [Field.name]: Field,
+    [FieldItem.name]: FieldItem,
   },
   data() {
     return {
@@ -46,6 +64,14 @@ export default {
       ],
       selectorValue: '',
     }
+  },
+  methods: {
+    showSelector() {
+      this.isSelectorShow = true
+    },
+    onSelectorConfirm({text}) {
+      this.selectorValue = text
+    },
   },
 }
 </script>

--- a/components/selector/test/cases/demo3.vue
+++ b/components/selector/test/cases/demo3.vue
@@ -1,23 +1,40 @@
 <template>
   <div class="md-example-child md-example-child-selector md-example-child-selector-3">
+    <md-field>
+      <md-field-item
+        title="Check模式"
+        :content="selectorValue"
+        @click="showSelector"
+        arrow
+      />
+    </md-field>
     <md-selector
-      value
+      v-model="isSelectorShow"
       :data="data[0]"
       title="Check模式"
       min-height="320px"
       okText="确认"
       cancelText="取消"
+      large-radius
+      @confirm="onSelectorConfirm"
       is-check
     ></md-selector>
   </div>
 </template>
 
-<script>import {Selector} from 'mand-mobile'
+<script>import {Selector, Field, FieldItem} from 'mand-mobile'
 
 export default {
   name: 'selector-demo',
+  /* DELETE */
+  title: 'Check模式',
+  titleEnUS: 'Check mode',
+  height: 500,
+  /* DELETE */
   components: {
     [Selector.name]: Selector,
+    [Field.name]: Field,
+    [FieldItem.name]: FieldItem,
   },
   data() {
     return {
@@ -35,6 +52,7 @@ export default {
           {
             value: '3',
             text: '选项三',
+            disabled: true,
           },
           {
             value: '4',
@@ -44,6 +62,14 @@ export default {
       ],
       selectorValue: '',
     }
+  },
+  methods: {
+    showSelector() {
+      this.isSelectorShow = true
+    },
+    onSelectorConfirm({text}) {
+      this.selectorValue = text
+    },
   },
 }
 </script>

--- a/components/selector/test/cases/demo4.vue
+++ b/components/selector/test/cases/demo4.vue
@@ -1,5 +1,13 @@
 <template>
   <div class="md-example-child md-example-child-selector md-example-child-selector-4">
+    <md-field>
+      <md-field-item
+        title="多选模式"
+        :content="selectorValue.join(',')"
+        @click="showSelector"
+        arrow
+      />
+    </md-field>
     <md-selector
       v-model="isSelectorShow"
       :data="data[0]"
@@ -8,17 +16,26 @@
       min-height="320px"
       okText="确定"
       cancelText="取消"
+      large-radius
+      @confirm="onSelectorConfirm"
       multi
     ></md-selector>
   </div>
 </template>
 
-<script>import {Selector} from 'mand-mobile'
+<script>import {Selector, Field, FieldItem} from 'mand-mobile'
 
 export default {
   name: 'selector-demo',
+  /* DELETE */
+  title: '多选模式',
+  titleEnUS: 'Multi mode',
+  height: 500,
+  /* DELETE */
   components: {
     [Selector.name]: Selector,
+    [Field.name]: Field,
+    [FieldItem.name]: FieldItem,
   },
   data() {
     return {
@@ -45,6 +62,14 @@ export default {
       ],
       selectorValue: ['1'],
     }
+  },
+  methods: {
+    showSelector() {
+      this.isSelectorShow = true
+    },
+    onSelectorConfirm(array) {
+      this.selectorValue = array
+    },
   },
 }
 </script>

--- a/components/tab-picker/demo/cases/demo0.vue
+++ b/components/tab-picker/demo/cases/demo0.vue
@@ -13,6 +13,7 @@
     <md-tab-picker
       title="请选择"
       describe="请选择您所在的省份、城市、区县"
+      large-radius
       :data="data"
       v-model="show"
       @change="handleChange"

--- a/components/tab-picker/demo/data.json
+++ b/components/tab-picker/demo/data.json
@@ -4,29 +4,29 @@
   "options": [
     {
       "value": "pk",
-      "label": "北京",
+      "label": "北京市",
       "children": {
         "name": "block",
-        "label": "",
+        "label": "请选择",
         "options": [
           {
             "value": "hd",
-            "label": "海淀"
+            "label": "海淀区"
           },
           {
             "value": "cp",
-            "label": "昌平"
+            "label": "昌平区"
           },
           {
             "value": "cy",
-            "label": "朝阳"
+            "label": "朝阳区"
           }
         ]
       }
     },
     {
       "value": "sc",
-      "label": "四川",
+      "label": "四川省",
       "children": {
         "name": "city",
         "label": "请选择",
@@ -36,7 +36,7 @@
             "label": "成都市",
             "children": {
               "name": "block",
-              "label": "区",
+              "label": "请选择",
               "options": [
                 {
                   "value": "gx",

--- a/components/tab-picker/index.vue
+++ b/components/tab-picker/index.vue
@@ -12,6 +12,8 @@
       <md-popup-title-bar
         :title="title"
         :describe="describe"
+        :large-radius="largeRadius"
+        only-close
         @cancel="$_onCancel"
       >
         <md-icon name="close" size="lg" slot="cancel" />
@@ -20,6 +22,7 @@
           <md-tabs
             v-model="currentTab"
             :key="tabsTmpKey"
+            :inkLength="100"
             ref="tabs"
           >
             <md-scroll-view


### PR DESCRIPTION
<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
金融设计规范设计调整，考虑到兼容问题，以下改动以新增props的方式实现

1. 弹窗类组件（`Popup`及其基于`Popup`组件）标题栏圆角尺寸，由`8px`调整为`40px`
2. 弹窗类组件标题栏支持单个关闭按钮，位置由左侧调整到右侧
3. 弹窗类组件标题栏标题描述位置可以居左/右/中

<image src="https://user-images.githubusercontent.com/8409100/61681218-32e62800-ad3f-11e9-9c79-3601fd9f15a0.png" width="200"><image src="https://user-images.githubusercontent.com/8409100/61681160-ea2e6f00-ad3e-11e9-9842-342f80e84f7f.png" width="200"><image src="https://user-images.githubusercontent.com/8409100/61695899-e7477480-ad66-11e9-8fe5-65504c92b849.png" width="200">

### 主要改动
<!-- 列举具体改动点 -->
1. `PopupTitleBar`增加属性`large-radius`，支持大圆角模式，默认为`false`(mixin)
2. `PopupTitleBar`增加属性`only-close`，支持单个关闭按钮，默认为`false`(mixin)
3. `PopupTitleBar`增加属性`title-align`，支持设置标题描述居左/右/中，默认为`center`(mixin)
4. `Picker`, `DatePicker`, `TabPicker`, `Selector`, `Cashier`, `ActionSheet`透传属性`large-radius`
5. `Selector`增加属性`hide-title-bar`，支持在无需确认模式下隐藏标题栏，增加插槽`header`，`footer`

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->

<!-- PR 内容区 -->