### PR TITLE
fix(stepper & input-item): avoid triggering change events when initia…

### DIFF
--- a/components/input-item/index.vue
+++ b/components/input-item/index.vue
@@ -298,8 +298,10 @@ export default {
     inputValue(val) {
       this.inputBindValue = val
       val = this.isFormative ? this.$_trimValue(val) : val
-      this.$emit('input', val)
-      this.$emit('change', this.name, val)
+      if (val !== this.value) {
+        this.$emit('input', val)
+        this.$emit('change', this.name, val)
+      }
     },
     isInputFocus(val) {
       if (!this.isVirtualKeyboard || !this.inputNumberKeyboard) {

--- a/components/stepper/README.en-US.md
+++ b/components/stepper/README.en-US.md
@@ -22,7 +22,6 @@ Vue.component(Stepper.name, Stepper)
 |Props | Description | Type | Default |
 |---------|------|--------|----|
 |v-model | current value | Number/String |-|
-|default-value |stepper initial value| Number/String|-|
 |step|the number of steps can be changed and be a decimal|Number/String|`1`|
 |min|minimum|Number/String|`-Infinity`|
 |max|maximum|Number/String|`Infinity`|

--- a/components/stepper/README.md
+++ b/components/stepper/README.md
@@ -22,7 +22,6 @@ Vue.component(Stepper.name, Stepper)
 |属性    | 说明 | 类型 | 默认值|
 |---------|------|--------|----|
 |v-model| 当前值 | Number/String |-|
-|default-value |默认值| Number/String|-|
 |step|每次改变步数，可以为小数|Number/String|`1`|
 |min|最小值|Number/String|`-Infinity`|
 |max|最大值|Number/String|`Infinity`|

--- a/components/stepper/index.vue
+++ b/components/stepper/index.vue
@@ -130,8 +130,10 @@ export default {
     currentNum(val, oldVal) {
       this.$_checkStatus()
 
-      this.$emit('input', val)
-      this.$emit('change', val)
+      if (val !== this.value) {
+        this.$emit('input', val)
+        this.$emit('change', val)
+      }
 
       const diff = val - oldVal
 


### PR DESCRIPTION
<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
Stepper 和 InputItem 组件在初始化时，如果Props的`value`值不为空会触发`change`事件，而此时的值其实并没有真正的改变，只是组件内用于表示值的局部变量(`currentValue`, `inputValue`)被第一次赋值而触发`watch`

### 主要改动
<!-- 列举具体改动点 -->
`watch`内部在触发`change`事件，需判断局部变量(`currentValue`, `inputValue`)和`value`的值是否相等，避免误触发

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->
某些特殊case下，`watch`内部的判断是否会导致正常的`change`事件无法触发

<!-- PR 内容区 -->