### PR TITLE
fix(amount): fixed the loss of precision in animation mode

### DIFF
--- a/components/amount/index.vue
+++ b/components/amount/index.vue
@@ -113,6 +113,10 @@ export default {
     $_doAnimateDisplay(fromValue = 0, toValue = 0) {
       /* istanbul ignore next  */
       const step = percent => {
+        if (percent === 1) {
+          this.formatValue = toValue
+          return
+        }
         this.formatValue = fromValue + (toValue - fromValue) * percent
       }
 

--- a/components/amount/test/index.spec.js
+++ b/components/amount/test/index.spec.js
@@ -1,5 +1,5 @@
 import {Amount} from 'mand-mobile'
-import {shallowMount} from '@vue/test-utils'
+import {shallowMount, mount} from '@vue/test-utils'
 
 describe('Amount - Operation', () => {
   let wrapper

--- a/components/amount/test/index.spec.js
+++ b/components/amount/test/index.spec.js
@@ -17,4 +17,37 @@ describe('Amount - Operation', () => {
     })
     expect(wrapper.vm.isMounted).toBe(true)
   })
+
+  test('should number animation not lose precision', done => {
+    wrapper = mount({
+      template: `
+          <md-amount
+          :value="val"
+          :duration="1000"
+          transition
+          ref="amount"
+        ></md-amount>
+      `,
+      components: {
+        [Amount.name]: Amount,
+      },
+      data() {
+        return {
+          val: 1000,
+        }
+      },
+    })
+
+    const instance = wrapper.vm.$refs.amount
+
+    setTimeout(() => {
+      expect(instance.formatValue).toBe(1000)
+      wrapper.vm.val = 20.66
+    }, 2000)
+
+    setTimeout(() => {
+      expect(instance.formatValue).toBe(20.66)
+      done()
+    }, 4000)
+  })
 })


### PR DESCRIPTION
背景描述
in transition mode, when the animation percent is 100%, the formateValue 's computed will lose precision

主要改动
when the animation percent is 100%, set the "formateValue"  as "toValue" and then return

需要注意
none