### PR TITLE
fix(input-item): limit the length of characters entered by the virtual keyboard

### DIFF
--- a/components/input-item/index.vue
+++ b/components/input-item/index.vue
@@ -498,6 +498,9 @@ export default {
       }
     },
     $_onNumberKeyBoardEnter(val) {
+      if (this.$_trimValue(this.inputValue).length >= this.inputMaxLength) {
+        return
+      }
       this.inputValue = this.$_formateValue(this.inputValue + val).value
     },
     $_onNumberKeyBoardDelete() {

--- a/components/input-item/test/index.spec.js
+++ b/components/input-item/test/index.spec.js
@@ -83,6 +83,7 @@ describe('InputItem - Operation', () => {
       propsData: {
         type: 'money',
         isVirtualKeyboard: true,
+        maxlength: 4,
       },
     })
 
@@ -102,6 +103,11 @@ describe('InputItem - Operation', () => {
       keys.at(2).trigger('click')
       deleteBtn.trigger('click')
       expect(wrapper.vm.inputValue).toBe('2.3')
+      keys.at(2).trigger('click')
+      keys.at(2).trigger('click')
+      keys.at(2).trigger('click')
+      keys.at(2).trigger('click')
+      expect(wrapper.vm.inputValue).toBe('2.33')
       confirmBtn.trigger('click')
       expect(eventStub.calledWith('confirm')).toBe(true)
       wrapper.vm.blur()


### PR DESCRIPTION
<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
当使用虚拟键盘向InputItem输入字符时，maxlength无法限制字符长度。

ps: 初始化赋值已限制字符长度

### 主要改动
<!-- 列举具体改动点 -->
在键盘输入事件时增加字符长度校验

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->
无

<!-- PR 内容区 -->