### PR TITLE
fix: add global reset style

### DIFF
--- a/components/_style/global.styl
+++ b/components/_style/global.styl
@@ -1,7 +1,28 @@
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed, 
+figure, figcaption, footer, header, hgroup, 
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video
+  margin 0
+  padding 0
+  border 0
+  font-size 100%
+  font inherit
+  vertical-align baseline
+  
+ol, li, ul
+  list-style none
+
 body
   font-family font-family-normal
   -webkit-tap-highlight-color transparent
   -webkit-font-smoothing antialiased
   -moz-osx-font-smoothing grayscale
-ol, li
-  list-style none


### PR DESCRIPTION
<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
ul, li, p 等格式化标签内部未去除默认样式，影响使用体验

### 主要改动
<!-- 列举具体改动点 -->
global.styl增加部分reset样式

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->

<!-- PR 内容区 -->