### PR TITLE
fix(button): change default slot wrapper from p to div

### DIFF
--- a/components/action-bar/test/__snapshots__/demo.spec.js.snap
+++ b/components/action-bar/test/__snapshots__/demo.spec.js.snap
@@ -8,9 +8,9 @@ exports[`ActionBar Demo Basic 1`] = `
       <div class="md-action-bar-group"><button type="button" class="md-button md-action-bar-button primary active block">
           <div class="md-button-inner">
             <!---->
-            <p class="md-button-content">
+            <div class="md-button-content">
               主要按钮
-            </p>
+            </div>
           </div>
         </button></div>
     </div>
@@ -26,16 +26,16 @@ exports[`ActionBar Demo Multiple buttons 1`] = `
       <div class="md-action-bar-group"><button type="button" class="md-button md-action-bar-button primary active block plain">
           <div class="md-button-inner">
             <!---->
-            <p class="md-button-content">
+            <div class="md-button-content">
               次要按钮
-            </p>
+            </div>
           </div>
         </button><button type="button" class="md-button md-action-bar-button primary active block">
           <div class="md-button-inner">
             <!---->
-            <p class="md-button-content">
+            <div class="md-button-content">
               主要按钮
-            </p>
+            </div>
           </div>
         </button></div>
     </div>
@@ -51,16 +51,16 @@ exports[`ActionBar Demo Multiple buttons and disabled button 1`] = `
       <div class="md-action-bar-group"><button type="button" disabled="disabled" class="md-button md-action-bar-button disabled active block plain">
           <div class="md-button-inner">
             <!---->
-            <p class="md-button-content">
+            <div class="md-button-content">
               次要按钮
-            </p>
+            </div>
           </div>
         </button><button type="button" disabled="disabled" class="md-button md-action-bar-button disabled active block">
           <div class="md-button-inner">
             <!---->
-            <p class="md-button-content">
+            <div class="md-button-content">
               主要按钮
-            </p>
+            </div>
           </div>
         </button></div>
     </div>
@@ -76,9 +76,9 @@ exports[`ActionBar Demo With slot 1`] = `
       <div class="md-action-bar-group"><button type="button" class="md-button md-action-bar-button primary active block">
           <div class="md-button-inner">
             <!---->
-            <p class="md-button-content">
+            <div class="md-button-content">
               主要按钮
-            </p>
+            </div>
           </div>
         </button></div>
     </div>

--- a/components/activity-indicator/test/__snapshots__/demo.spec.js.snap
+++ b/components/activity-indicator/test/__snapshots__/demo.spec.js.snap
@@ -25,7 +25,7 @@ exports[`ActivityIndicator Carousel 1`] = `
   </div> <button type="button" class="md-button primary active block">
     <div class="md-button-inner">
       <!---->
-      <p class="md-button-content"><span>确认支付</span></p>
+      <div class="md-button-content"><span>确认支付</span></div>
     </div>
   </button>
 </div>

--- a/components/button/index.vue
+++ b/components/button/index.vue
@@ -20,9 +20,9 @@
       <template v-else-if="icon">
         <md-icon :name="icon" :svg="iconSvg"></md-icon>
       </template>
-      <p class="md-button-content">
+      <div class="md-button-content">
         <slot></slot>
-      </p>
+      </div>
     </div>
   </button>
 </template>

--- a/components/button/test/__snapshots__/demo.spec.js.snap
+++ b/components/button/test/__snapshots__/demo.spec.js.snap
@@ -4,22 +4,22 @@ exports[`Button Basic 1`] = `
 <div class="md-example-child md-example-child-button md-example-child-button-0"><button type="button" class="md-button default active block">
     <div class="md-button-inner">
       <!---->
-      <p class="md-button-content">Default</p>
+      <div class="md-button-content">Default</div>
     </div>
   </button> <button type="button" disabled="disabled" class="md-button default inactive block">
     <div class="md-button-inner">
       <!---->
-      <p class="md-button-content">Default Inactive</p>
+      <div class="md-button-content">Default Inactive</div>
     </div>
   </button> <button type="button" class="md-button primary active block">
     <div class="md-button-inner">
       <!---->
-      <p class="md-button-content">Primary</p>
+      <div class="md-button-content">Primary</div>
     </div>
   </button> <button type="button" disabled="disabled" class="md-button primary inactive block">
     <div class="md-button-inner">
       <!---->
-      <p class="md-button-content">Primary Inactive</p>
+      <div class="md-button-content">Primary Inactive</div>
     </div>
   </button> <button type="button" class="md-button primary active block">
     <div class="md-button-inner">
@@ -36,22 +36,22 @@ exports[`Button Basic 1`] = `
           <div class="content"></div>
         </div>
       </div>
-      <p class="md-button-content">Loading</p>
+      <div class="md-button-content">Loading</div>
     </div>
   </button> <button type="button" class="md-button warning active block">
     <div class="md-button-inner">
       <!---->
-      <p class="md-button-content">Warning</p>
+      <div class="md-button-content">Warning</div>
     </div>
   </button> <button type="button" disabled="disabled" class="md-button warning inactive block">
     <div class="md-button-inner">
       <!---->
-      <p class="md-button-content">Warning Inactive</p>
+      <div class="md-button-content">Warning Inactive</div>
     </div>
   </button> <button type="button" disabled="disabled" class="md-button disabled active block">
     <div class="md-button-inner">
       <!---->
-      <p class="md-button-content">Disabled</p>
+      <div class="md-button-content">Disabled</div>
     </div>
   </button></div>
 `;
@@ -60,23 +60,23 @@ exports[`Button Inline 1`] = `
 <div class="md-example-child  md-example-child-button md-example-child-button-3">
   <div class="md-example-section"><button type="button" class="md-button primary active inline">
       <div class="md-button-inner"><i class="md-icon icon-font md-icon-edit edit md" style="color:;"></i>
-        <p class="md-button-content">Inline Primary</p>
+        <div class="md-button-content">Inline Primary</div>
       </div>
     </button> <button type="button" class="md-button primary active inline plain">
       <div class="md-button-inner">
         <!---->
-        <p class="md-button-content">Inline Plain</p>
+        <div class="md-button-content">Inline Plain</div>
       </div>
     </button></div>
   <div class="md-example-section"><button type="button" class="md-button warning active inline small">
       <div class="md-button-inner">
         <!---->
-        <p class="md-button-content">Warning</p>
+        <div class="md-button-content">Warning</div>
       </div>
     </button> <button type="button" disabled="disabled" class="md-button disabled active inline small">
       <div class="md-button-inner">
         <!---->
-        <p class="md-button-content">Disabled</p>
+        <div class="md-button-content">Disabled</div>
       </div>
     </button></div>
 </div>
@@ -86,27 +86,27 @@ exports[`Button Plain 1`] = `
 <div class="md-example-child md-example-child-button md-example-child-button-1"><button type="button" class="md-button default active block plain">
     <div class="md-button-inner">
       <!---->
-      <p class="md-button-content">Default &amp; Plain</p>
+      <div class="md-button-content">Default &amp; Plain</div>
     </div>
   </button> <button type="button" class="md-button primary active block plain">
     <div class="md-button-inner">
       <!---->
-      <p class="md-button-content">Primary &amp; Plain</p>
+      <div class="md-button-content">Primary &amp; Plain</div>
     </div>
   </button> <button type="button" class="md-button warning active block plain">
     <div class="md-button-inner">
       <!---->
-      <p class="md-button-content">Warning &amp; Plain</p>
+      <div class="md-button-content">Warning &amp; Plain</div>
     </div>
   </button> <button type="button" disabled="disabled" class="md-button disabled active block plain">
     <div class="md-button-inner">
       <!---->
-      <p class="md-button-content">Disabled &amp; Plain</p>
+      <div class="md-button-content">Disabled &amp; Plain</div>
     </div>
   </button> <button type="button" class="md-button primary active block round plain">
     <div class="md-button-inner">
       <!---->
-      <p class="md-button-content">Primary &amp; Plain &amp; Round</p>
+      <div class="md-button-content">Primary &amp; Plain &amp; Round</div>
     </div>
   </button> <button type="button" class="md-button primary active block round plain">
     <div class="md-button-inner">
@@ -123,7 +123,7 @@ exports[`Button Plain 1`] = `
           <div class="content"></div>
         </div>
       </div>
-      <p class="md-button-content">Primary &amp; Plain &amp; Loading</p>
+      <div class="md-button-content">Primary &amp; Plain &amp; Loading</div>
     </div>
   </button></div>
 `;
@@ -132,22 +132,22 @@ exports[`Button Round 1`] = `
 <div class="md-example-child md-example-child-button md-example-child-button-2"><button type="button" class="md-button default active block round">
     <div class="md-button-inner">
       <!---->
-      <p class="md-button-content">Default &amp; Round</p>
+      <div class="md-button-content">Default &amp; Round</div>
     </div>
   </button> <button type="button" class="md-button primary active block round">
     <div class="md-button-inner">
       <!---->
-      <p class="md-button-content">Primary &amp; Round</p>
+      <div class="md-button-content">Primary &amp; Round</div>
     </div>
   </button> <button type="button" class="md-button warning active block round">
     <div class="md-button-inner">
       <!---->
-      <p class="md-button-content">Warning &amp; Round</p>
+      <div class="md-button-content">Warning &amp; Round</div>
     </div>
   </button> <button type="button" disabled="disabled" class="md-button disabled active block round">
     <div class="md-button-inner">
       <!---->
-      <p class="md-button-content">Disabled &amp; Round</p>
+      <div class="md-button-content">Disabled &amp; Round</div>
     </div>
   </button></div>
 `;
@@ -155,12 +155,12 @@ exports[`Button Round 1`] = `
 exports[`Button Text link 1`] = `
 <div class="md-example-child  md-example-child-button md-example-child-button-3"><button type="button" class="md-button link active block">
     <div class="md-button-inner"><i class="md-icon icon-font md-icon-message message md" style="color:;"></i>
-      <p class="md-button-content">评论</p>
+      <div class="md-button-content">评论</div>
     </div>
   </button> <button type="button" disabled="disabled" class="md-button link inactive block">
     <div class="md-button-inner">
       <!---->
-      <p class="md-button-content">去看看<i class="md-icon icon-font md-icon-arrow-right arrow-right md" style="color:;"></i></p>
+      <div class="md-button-content">去看看<i class="md-icon icon-font md-icon-arrow-right arrow-right md" style="color:;"></i></div>
     </div>
   </button></div>
 `;

--- a/components/cashier/test/__snapshots__/demo.spec.js.snap
+++ b/components/cashier/test/__snapshots__/demo.spec.js.snap
@@ -101,7 +101,7 @@ exports[`Cashier - Demo Baisc-channel 1`] = `
               <div class="md-cashier-block-btn"><button type="button" class="md-button md-cashier-pay-button primary active block">
                   <div class="md-button-inner">
                     <!---->
-                    <p class="md-button-content">确定支付</p>
+                    <div class="md-button-content">确定支付</div>
                   </div>
                 </button></div>
             </div>
@@ -235,7 +235,7 @@ exports[`Cashier - Demo Using slots and other configurations 1`] = `
               <div class="md-cashier-block-btn"><button type="button" class="md-button md-cashier-pay-button primary active block">
                   <div class="md-button-inner">
                     <!---->
-                    <p class="md-button-content">确定支付</p>
+                    <div class="md-button-content">确定支付</div>
                   </div>
                 </button></div>
             </div>

--- a/components/dialog/test/__snapshots__/demo.spec.js.snap
+++ b/components/dialog/test/__snapshots__/demo.spec.js.snap
@@ -4,32 +4,32 @@ exports[`Dialog - Demo Basic 1`] = `
 <div class="md-example-child md-example-child-dialog md-example-child-dialog-0"><button type="button" class="md-button default active block">
     <div class="md-button-inner">
       <!---->
-      <p class="md-button-content">基本</p>
+      <div class="md-button-content">基本</div>
     </div>
   </button> <button type="button" class="md-button default active block">
     <div class="md-button-inner">
       <!---->
-      <p class="md-button-content">带图标</p>
+      <div class="md-button-content">带图标</div>
     </div>
   </button> <button type="button" class="md-button default active block">
     <div class="md-button-inner">
       <!---->
-      <p class="md-button-content">警示操作</p>
+      <div class="md-button-content">警示操作</div>
     </div>
   </button> <button type="button" class="md-button default active block">
     <div class="md-button-inner">
       <!---->
-      <p class="md-button-content">异步操作</p>
+      <div class="md-button-content">异步操作</div>
     </div>
   </button> <button type="button" class="md-button default active block">
     <div class="md-button-inner">
       <!---->
-      <p class="md-button-content">多操作</p>
+      <div class="md-button-content">多操作</div>
     </div>
   </button> <button type="button" class="md-button default active block">
     <div class="md-button-inner">
       <!---->
-      <p class="md-button-content">插槽</p>
+      <div class="md-button-content">插槽</div>
     </div>
   </button>
   <div class="md-dialog">

--- a/components/result-page/test/__snapshots__/demo.spec.js.snap
+++ b/components/result-page/test/__snapshots__/demo.spec.js.snap
@@ -42,16 +42,16 @@ exports[`ResultPage With button 1`] = `
     <div class="md-result-buttons"><button type="button" class="md-button default active inline plain small">
         <div class="md-button-inner">
           <!---->
-          <p class="md-button-content">
+          <div class="md-button-content">
             普通按钮
-          </p>
+          </div>
         </div>
       </button><button type="button" class="md-button primary active inline plain small">
         <div class="md-button-inner">
           <!---->
-          <p class="md-button-content">
+          <div class="md-button-content">
             高亮按钮
-          </p>
+          </div>
         </div>
       </button></div>
   </div>


### PR DESCRIPTION
### 背景描述
button 原有的 defaultSlot wrapper 是 p 标签, 存在样式没有重置的问题，且现在 slot 的内容多种多样，因此将 defaultSlot 的 wrapper 改为 div 标签

### 主要改动
<!-- 列举具体改动点 -->
修改 button defaultSlot wrapper 标签 p -> div

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->
是否影响原有样式
<!-- PR 内容区 -->
