### PR TITLE
feat(action-bar & result-page): add props for buttons configration

### DIFF
--- a/components/action-bar/README.en-US.md
+++ b/components/action-bar/README.en-US.md
@@ -26,7 +26,22 @@ ActionBar is fixed at the bottom of the page by `position: fixed`. In order to a
 #### ActionBar Props
 |Props | Description | Type | Default | Note|
 |----|-----|------|------|------|
-|actions|button group|Array<{text, disabled, onClick}>|-|`text` is button text,<br/>`disabled`is whether to disable the button or not,<br/>`onClick`is click event callback function with the same parameters as the `click` event|
+|actions|button group|Array\<ActionOptions\>|-|-|
+
+#### ActionOptions Props
+
+|属性 | 说明 | 类型 | 默认值|
+|----|-----|------|------|
+|text|-|String|-|
+|disabled|-|Boolean|`false`|
+|onClick|click handler|Function(action: ActionOptions)|-|
+|type|-|String|`disabled` when the prop `disabled` is true, otherwise is `primary`|
+|plain|-|Boolean|`false` for the last one and `true` for the others|
+|round|-|Boolean|`false`|
+|icon|icon name|String|-|
+|iconSvg|use svg icon|Boolean|`false`|
+|inactive|-|Boolean|`false`|
+|loading|-|Boolean|`false`|
 
 #### ActionBar Slots
 
@@ -40,4 +55,4 @@ Button click event
 
 |Props | Description | Type |
 |----|-----|------|
-|action|object corresponding to the clicked button in the actions list|Object: {text, disabled, ...}|
+|action|object corresponding to the clicked button in the actions list|Object: ActionOptions|

--- a/components/action-bar/README.md
+++ b/components/action-bar/README.md
@@ -27,7 +27,22 @@ Vue.component(ActionBar.name, ActionBar)
 #### ActionBar Props
 |属性 | 说明 | 类型 | 默认值 | 备注|
 |----|-----|------|------|------|
-|actions|按钮组|Array<{text, disabled, onClick}>|-|`text`为按钮文案，<br/>`disabled`为是否禁用该按钮，<br/>`onClick`为点击事件响应函数，传参数与`click`事件相同|
+|actions|按钮组|Array\<ActionOptions\>|-|-|
+
+#### ActionOptions Props
+
+|属性 | 说明 | 类型 | 默认值|
+|----|-----|------|------|
+|text|文案|String|-|
+|disabled|禁用|Boolean|`false`|
+|onClick|点击回调|Function(action: ActionOptions)|-|
+|type|类型|String|`disabled`为`true`时为`disabled`，否则为`primary`|
+|plain|朴素|Boolean|最后一个按钮为`false`，其它为`true`|
+|round|圆角|Boolean|`false`|
+|icon|按钮图标|String|-|
+|iconSvg|按钮svg图标|Boolean|`false`|
+|inactive|未激活|Boolean|`false`|
+|loading|加载中状态|Boolean|`false`|
 
 #### ActionBar Slots
 
@@ -41,4 +56,4 @@ Vue.component(ActionBar.name, ActionBar)
 
 |属性 | 说明 | 类型 |
 |----|-----|------|
-|action|actions列表中与被点击按钮对应的对象|Object: {text, disabled, ...}|
+|action|actions列表中与被点击按钮对应的对象|Object: ActionOptions|

--- a/components/action-bar/demo/cases/demo3.vue
+++ b/components/action-bar/demo/cases/demo3.vue
@@ -25,14 +25,21 @@ export default {
       data: [
         {
           text: '主要按钮',
+          round: true,
         },
       ],
     }
   },
   methods: {
     onBtnClick(event, action) {
+      this.$set(action, 'loading', true)
+      this.$set(action, 'inactive', true)
       Dialog.alert({
         content: `${action.text}点击`,
+        onConfirm: () => {
+          this.$set(action, 'loading', false)
+          this.$set(action, 'inactive', false)
+        },
       })
     },
   },

--- a/components/action-bar/index.vue
+++ b/components/action-bar/index.vue
@@ -8,8 +8,13 @@
         <template v-for="(item, index) in coerceActions">
           <md-button
             class="md-action-bar-button"
-            :type="!!item.disabled ? 'disabled' : 'primary'"
-            :plain="index !== coerceActions.length - 1"
+            :type="item.type || (!!item.disabled ? 'disabled' : 'primary')"
+            :plain="item.plain || (index !== coerceActions.length - 1)"
+            :round="item.round"
+            :inactive="item.inactive"
+            :loading="item.loading"
+            :icon="item.icon"
+            :icon-svg="item.iconSvg"
             :key="index"
             @click="$_onBtnClick($event, item)"
           >

--- a/components/result-page/README.en-US.md
+++ b/components/result-page/README.en-US.md
@@ -37,3 +37,9 @@ It is recommended to set the parent element filled with windows to achieve cente
 |text | button text | String | - | - |
 |type | button style | String | `default` | refer to `Button` |
 |handler | callback of click operation | Function | - | callback function invoked after clicking |
+|plain|-|Boolean|`false` for the last one and `true` for the others|-|
+|round|-|Boolean|`false`|-|
+|icon|icon name|String|-|-|
+|iconSvg|use svg icon|Boolean|`false`|-|
+|inactive|-|Boolean|`false`|-|
+|loading|-|Boolean|`false`|-|

--- a/components/result-page/README.md
+++ b/components/result-page/README.md
@@ -37,3 +37,9 @@ Vue.component(ResultPage.name, ResultPage)
 |text | 按钮文字 | String | - | - |
 |type | 按钮样式类别 | String | `default` | 可参考`Button` |
 |handler | 点击操作 | Function | - | 点击按钮后调用的方法 |
+|plain|朴素|Boolean|最后一个按钮为`false`，其它为`true`|
+|round|圆角|Boolean|`false`|-|
+|icon|按钮图标|String|-|-|
+|iconSvg|按钮svg图标|Boolean|`false`|-|
+|inactive|未激活|Boolean|`false`|-|
+|loading|加载中状态|Boolean|`false`|-|

--- a/components/result-page/index.vue
+++ b/components/result-page/index.vue
@@ -9,9 +9,14 @@
       <md-button
         v-for="(button, index) of buttons"
         :type="button.type"
-        plain
-        inline
+        :plain="button.plain === undefined || button.plain"
+        :round="button.round"
+        :inactive="button.inactive"
+        :loading="button.loading"
+        :icon="button.icon"
+        :icon-svg="button.iconSvg"
         size="small"
+        inline
         :key="index"
         @click="button.handler">
         {{button.text}}


### PR DESCRIPTION
<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
ActionBar和ResultPage内部使用`Button`但可配置项过少，故补充一些配置属性 #544 

### 主要改动
<!-- 列举具体改动点 -->
增加`type `, `plain`, `round`, `inactive`, `loading`, `icon`, `iconSvg`(根据设计规范，无`inline`和`size`)

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->
出现在配置中的以上属性有**更高的优先级**，原来部分属性值作为默认值（如ActionBar默认最后一个按钮类型为`plain`为`false`，其他按钮为`true`）

<!-- PR 内容区 -->