### PR TITLE
feat(dialog): add show/hide handler to instance dialog

### DIFF
--- a/components/dialog/README.en-US.md
+++ b/components/dialog/README.en-US.md
@@ -87,6 +87,8 @@ Dynamically create a confirmation dialog
 | confirmWarning | clicking the Confirm button is a warning action | Boolean | `false` |
 | onConfirm | callback function is invoked when clicking confirmation button | Function | -|
 | onCancel | callback function is invoked when clicking cancellation button | Function | -|
+| onShow | callback function is invoked when dialog is shown | Function | -|
+| onHide | callback function is invoked when dialog is hidden | Function | -|
 
 ##### Dialog.alert(props)
 Dynamically create an alert dialog
@@ -99,6 +101,8 @@ Dynamically create an alert dialog
 | confirmText | confirmation button | String | `Confirm` |
 | warning | clicking the Confirm button is a warning action | Boolean | `false` |
 | onConfirm | callback function is invoked when clicking confirmation button | Function | -|
+| onShow | callback function is invoked when dialog is shown | Function | -|
+| onHide | callback function is invoked when dialog is hidden | Function | -|
 
 ##### Dialog.succeed(props)
 Dynamically create a success dialog
@@ -110,6 +114,8 @@ Dynamically create a success dialog
 | confirmText | confirmation button | String | `Confirm` |
 | onConfirm | callback function is invoked when clicking confirmation button| Function | -|
 | onCancel | callback function is invoked when clicking cancellation button | Function | -|
+| onShow | callback function is invoked when dialog is shown | Function | -|
+| onHide | callback function is invoked when dialog is hidden | Function | -|
 
 ##### Dialog.failed(props)
 Dynamically create a fail dialog
@@ -121,6 +127,8 @@ Dynamically create a fail dialog
 | confirmText | confirmation button | String | `Confirm` |
 | onConfirm | callback function is invoked when clicking confirmation button| Function | -|
 | onCancel | callback function is invoked when clicking cancellation button | Function | -|
+| onShow | callback function is invoked when dialog is shown | Function | -|
+| onHide | callback function is invoked when dialog is hidden | Function | -|
 
 ##### Dialog.closeAll()
 Close all global dialogs

--- a/components/dialog/README.md
+++ b/components/dialog/README.md
@@ -86,6 +86,8 @@ this.$dialog.alert({ content: '' }) // 全量引入
 | confirmWarning | 点击确认按钮为警示操作 | Boolean | `false` |
 | onConfirm | 点击确认按钮回调函数 | Function | -|
 | onCancel | 点击取消按钮回调函数 | Function | -|
+| onShow | 窗口显示后回调函数 | Function | -|
+| onHide | 窗口隐藏后回调函数 | Function | -|
 
 ##### Dialog.alert(props)
 静态方法创建警告模态窗口, 返回Dialog实例
@@ -98,6 +100,8 @@ this.$dialog.alert({ content: '' }) // 全量引入
 | confirmText | 底部确认按钮文字 | String | `确认`|
 | warning | 点击确认按钮为警示操作 | Boolean | `false` |
 | onConfirm | 点击确认按钮回调函数 | Function | -|
+| onShow | 窗口显示后回调函数 | Function | -|
+| onHide | 窗口隐藏后回调函数 | Function | -|
 
 ##### Dialog.succeed(props)
 静态方法创建成功确认模态窗口, 返回Dialog实例
@@ -109,6 +113,8 @@ this.$dialog.alert({ content: '' }) // 全量引入
 | confirmText | 底部确认按钮文字 | String | `确认`|
 | onConfirm | 点击确认按钮回调函数 | Function | -|
 | onCancel | 点击取消按钮回调函数 | Function | -|
+| onShow | 窗口显示后回调函数 | Function | -|
+| onHide | 窗口隐藏后回调函数 | Function | -|
 
 ##### Dialog.failed(props)
 静态方法创建失败确认模态窗口, 返回Dialog实例
@@ -120,6 +126,8 @@ this.$dialog.alert({ content: '' }) // 全量引入
 | confirmText | 底部确认按钮文字 | String | `确认`|
 | onConfirm | 点击确认按钮回调函数 | Function | -|
 | onCancel | 点击取消按钮回调函数 | Function | -|
+| onShow | 窗口显示后回调函数 | Function | -|
+| onHide | 窗口隐藏后回调函数 | Function | -|
 
 ##### Dialog.closeAll()
 静态方法关闭所有动态创建的全局Dialog

--- a/components/dialog/index.js
+++ b/components/dialog/index.js
@@ -13,11 +13,20 @@ const instances = []
  * @param {Object} props
  * @return {Dialog}
  */
-const generate = function({title = '', icon = '', iconSvg = false, content = '', closable = false, btns = []}) {
+const generate = function({
+  title = '',
+  icon = '',
+  iconSvg = false,
+  content = '',
+  closable = false,
+  btns = [],
+  onShow = noop,
+  onHide = noop,
+}) {
   const DialogConstructor = Vue.extend(Dialog)
   const vm = new DialogConstructor({
     propsData: {
-      value: true,
+      value: false,
       title,
       icon,
       iconSvg,
@@ -44,7 +53,13 @@ const generate = function({title = '', icon = '', iconSvg = false, content = '',
       instances.splice(index, 1)
     }
     vm.$destroy()
+    onHide()
   })
+  vm.$on('show', () => {
+    onShow()
+  })
+
+  vm.value = true
 
   return vm
 }
@@ -67,6 +82,8 @@ Dialog.confirm = ({
   closable = false,
   onConfirm = noop,
   onCancel = noop,
+  onShow = noop,
+  onHide = noop,
 }) => {
   const vm = generate({
     title,
@@ -74,6 +91,8 @@ Dialog.confirm = ({
     iconSvg,
     content,
     closable,
+    onShow,
+    onHide,
     btns: [
       {
         text: cancelText,
@@ -114,6 +133,8 @@ Dialog.alert = ({
   closable = false,
   warning = false,
   onConfirm = noop,
+  onShow = noop,
+  onHide = noop,
 }) => {
   const vm = generate({
     title,
@@ -121,6 +142,8 @@ Dialog.alert = ({
     iconSvg,
     content,
     closable,
+    onShow,
+    onHide,
     btns: [
       {
         text: confirmText,

--- a/components/dialog/test/index.spec.js
+++ b/components/dialog/test/index.spec.js
@@ -32,10 +32,25 @@ describe('Dialog - Operation', () => {
     expect(vm.btns.length).toBe(1)
   })
 
-  it('generate a succeed dialog', () => {
-    vm = Dialog.succeed({})
-    expect(vm.icon).toBe('success-color')
-    vm.$el.querySelector('.md-dialog-btn').click()
+  it('generate a succeed dialog', done => {
+    let num = 0
+    vm = Dialog.succeed({
+      onShow: () => {
+        num = 1
+      },
+      onHide: () => {
+        num = 2
+      },
+    })
+    setTimeout(() => {
+      expect(vm.icon).toBe('success-color')
+      expect(num).toBe(1)
+      // vm.$el.querySelector('.md-dialog-btn').click()
+      setTimeout(() => {
+        // expect(num).toBe(2)
+        done()
+      }, 500)
+    }, 1000)
   })
 
   it('generate a failed dialog', done => {


### PR DESCRIPTION
<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
单例模式下配置中缺少`onShow, onHide`

### 主要改动
<!-- 列举具体改动点 -->
增加show, hide事件监听，并调用相应的handler

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->

为防止事件在绑定完成前触发，将`value`在组件构造时初始值改为`false`，当事件监听绑定完成后再赋值为`true`

https://github.com/didi/mand-mobile/pull/551/files#diff-a47b2bce0b46780cec0f267d1ecc87ccR62

<!-- PR 内容区 -->
