### PR TITLE
feat(input-item): add prop preview-type & optimize virtual cursor

### DIFF
--- a/components/input-item/README.en-US.md
+++ b/components/input-item/README.en-US.md
@@ -26,6 +26,7 @@ Vue.component(InputItem.name, InputItem)
 |Props | Description | Type | Default | Note |
 |----|-----|------|------|------|
 |type|input type, special type has text formatting|String|`text`|`text`,`bankCard`,`phone`,<br/>`money`,`password`|
+|preview-type|input preview type|String|-|generally used for initial input value (such as masked *ID number with mobile phone number, mobile phone number*) preview and the first time you trigger an edit operation, such as clicking the backspace key and other character key clicks, ** the pre-fill value will be cleared first and the input will be switched to `type` **|
 |name|name of input|String|-|one of the event arguments, is used to distinguish multi inputs|
 |v-model|value of input|String|-|-|
 |title|title of input|String|-|`slot left` as alternative|

--- a/components/input-item/README.md
+++ b/components/input-item/README.md
@@ -27,6 +27,7 @@ Vue.component(InputItem.name, InputItem)
 |属性 | 说明 | 类型 | 默认值 | 备注|
 |----|-----|------|------|------|
 |type|表单类型，特殊类型自带文本格式化|String|`text`|`text(文本)`,`bankCard(银行卡号)`,`phone(手机号)`,<br/>`money(金额)`,`digit(数字)`,`password(密码)`,<br/>以及其他的标准`Html Input`类型|
+|preview-type|表单预览类型|String|-|一般用于初始化时的特殊表单值（如带掩码的*身份证号，手机号*）预览，第一次触发编辑操作如点击退格键及其他字符键点击时，先**清空预填值并将表单类型切换至`type`**|
 |name|表单名称|String|-|事件入参之一，可用于区分表单组件|
 |v-model|表单值|String|-|-|
 |title|表单左侧标题|String|-|可直接使用`slot left`代替|

--- a/components/input-item/demo/cases/demo1.vue
+++ b/components/input-item/demo/cases/demo1.vue
@@ -3,17 +3,21 @@
     <md-field>
       <md-input-item
         ref="name"
+        preview-type="text"
+        value="张**"
         title="真实姓名"
         placeholder="投保人姓名"
         is-title-latent
-        clearable
       ></md-input-item>
       <md-input-item
         ref="id"
-        title="身份证号"
-        placeholder="投保人身份证号"
+        type="bankCard"
+        preview-type="text"
+        value="6222 **** **** 1234"
+        title="银行卡号"
+        placeholder="投保人银行卡号"
         is-title-latent
-        clearable
+        is-virtual-keyboard
         ></md-input-item>
     </md-field>
   </div>

--- a/components/input-item/test/__snapshots__/demo.spec.js.snap
+++ b/components/input-item/test/__snapshots__/demo.spec.js.snap
@@ -209,7 +209,7 @@ exports[`InputItem - Demo input with controls 1`] = `
         <div class="md-field-item-content"><label class="md-field-item-title">金融键盘</label>
           <!---->
           <div class="md-field-item-control">
-            <div class="md-input-item-fake"><span></span> <span class="md-input-item-fake-placeholder">financial number keyboard</span></div>
+            <div class="md-input-item-fake is-waiting"><span></span> <span class="md-input-item-fake-placeholder">financial number keyboard</span></div>
           </div>
           <div class="md-field-item-right">
             <div class="md-input-item-clear" style="display:none;"><i class="md-icon icon-font md-icon-clear clear md" style="color:;"></i></div>

--- a/components/input-item/test/index.spec.js
+++ b/components/input-item/test/index.spec.js
@@ -24,6 +24,7 @@ describe('InputItem - Operation', () => {
     wrapper.vm.focus()
     triggerEvent(input.element, 'keydown', 0, 0, 49)
     triggerEvent(input.element, 'keyup', 0, 0, 49)
+    expect(wrapper.vm.isInputEditing).toBe(true)
 
     triggerEvent(input.element, 'keydown', 0, 0, 11)
     triggerEvent(input.element, 'keyup', 0, 0, 11)
@@ -34,6 +35,30 @@ describe('InputItem - Operation', () => {
     expect(eventStub.calledWith('confirm')).toBe(true)
     expect(wrapper.vm.getValue()).toEqual('4949 1111 1313 123')
     wrapper.vm.blur()
+  })
+
+  test('input-item preview-type', () => {
+    wrapper = mount(InputItem, {
+      propsData: {
+        type: 'bankCard',
+        previewType: 'text',
+        value: '123',
+      },
+    })
+    expect(wrapper.vm.inputItemType).toBe('text')
+    expect(wrapper.vm.isInputFormative).toBe(false)
+    expect(wrapper.vm.inputType).toBe('text')
+
+    const input = wrapper.find('.md-input-item-input')
+    wrapper.vm.focus()
+    triggerEvent(input.element, 'keydown', 0, 0, 13)
+    triggerEvent(input.element, 'keyup', 0, 0, 13)
+    expect(wrapper.vm.getValue()).toEqual('123')
+    triggerEvent(input.element, 'keydown', 0, 0, 8)
+    triggerEvent(input.element, 'keyup', 0, 0, 8)
+    expect(wrapper.vm.getValue()).toEqual('')
+    expect(wrapper.vm.inputItemType).toBe('bankCard')
+    expect(wrapper.vm.isInputFormative).toBe(true)
   })
 
   test('phone input-item', () => {
@@ -102,6 +127,7 @@ describe('InputItem - Operation', () => {
       keys.at(2).trigger('click')
       keys.at(2).trigger('click')
       deleteBtn.trigger('click')
+      expect(wrapper.vm.isInputEditing).toBe(true)
       expect(wrapper.vm.inputValue).toBe('2.3')
       keys.at(2).trigger('click')
       keys.at(2).trigger('click')
@@ -111,7 +137,10 @@ describe('InputItem - Operation', () => {
       confirmBtn.trigger('click')
       expect(eventStub.calledWith('confirm')).toBe(true)
       wrapper.vm.blur()
-      done()
+      setTimeout(() => {
+        expect(wrapper.vm.isInputEditing).toBe(false)
+        done()
+      }, 500)
     }, 500)
   })
 


### PR DESCRIPTION
<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->

一、 缺少对特殊表单值（如带掩码的*身份证号，手机号*）的预览场景支持，此场景需衍生出一种特殊状态**预填展示时**，与**正常输入时**相比有以下几种特殊交互：
  * 当用户做出编辑操作，如点击退格键及其他字符键点击时，先**清空预填值**
  * 用于预填展示时和正常输入状态是表单类型可能不一致，当预填值被清空后需**将表单类型切换至输入状态的表单类型**

二、优化使用虚拟键盘的虚拟光标闪烁逻辑，**当表单处于编辑状态时不闪烁，停止编辑500ms后开始闪烁**

### 主要改动
<!-- 列举具体改动点 -->
增加`preview-type`，用于设置表单**预填展示时**的类型

```html
<md-input-item
  type="bankCard" <!-- 正常输入时表单类型 -->
  preview-type="text" <!-- 预填展示时表单类型 -->
  title="银行卡号"
  value="6222 **** **** 1234"  <!-- 带掩码的预填值-->
></md-input-item>

<!-- 如果需控制两种状态切换 -->
<md-input-item
  type="bankCard"
  :preview-type.sync="previewType" 
  title="银行卡号"
  value="6222 **** **** 1234"
></md-input-item>
```
### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->
`preivew-type`引入后，表单类型在不同状态切换时转换是否正常

<!-- PR 内容区 -->