### PR TITLE
modify stepper input type prop

### DIFF
--- a/components/stepper/index.vue
+++ b/components/stepper/index.vue
@@ -10,7 +10,8 @@
     >
     </div>
     <div class="md-stepper-number">
-      <input type="tel"
+      <input 
+        :type="inputType"
         :size="contentLength"
         :value="currentNum"
         :readOnly="readOnly"
@@ -26,7 +27,8 @@
   </div>
 </template>
 
-<script>import {warn} from '../_util'
+<script>
+import {warn} from '../_util'
 function getDecimalNum(num) {
   try {
     return num.toString().split('.')[1].length
@@ -56,6 +58,10 @@ export default {
   components: {},
 
   props: {
+    inputType: {
+      type: [String],
+      default: "tel",
+    },
     defaultValue: {
       type: [Number, String],
       default: 0,
@@ -202,7 +208,8 @@ export default {
     },
   },
 }
-</script>
+
+</script>
 
 <style lang="stylus">
 .md-stepper


### PR DESCRIPTION
### 背景描述
Stepper 步进器，输入框 input 弹出输入键盘为 tel 类型，只支持输入整数，不支持用户输入小数点

### 主要改动
1. Stepper input 类型支持 props 设置

### 需要注意
1. 默认值为 tel
