### PR TITLE
fix(tab-bar): fix tab-bar with reflow

### DIFF
--- a/components/tab-bar/index.vue
+++ b/components/tab-bar/index.vue
@@ -255,6 +255,7 @@ export default {
   min-width 100%
 
 .md-tab-bar-item
+  flex auto
   flex-shrink 0
   position relative
   display inline-flex


### PR DESCRIPTION
fix #567

### 背景描述
tab-bar的父级宽度使用vw + 百分比，会导致内部flex计算数值不准确，导致内部item宽度变化，最终触发死循环计算reflow

### 主要改动
md-tab-bar-item添加flex: auto

### 需要注意
无
