### PR TITLE
feat(picker & date-picker): add prop keep-index

### DIFF
--- a/components/date-picker/README.en-US.md
+++ b/components/date-picker/README.en-US.md
@@ -30,7 +30,8 @@ Vue.component(DatePicker.name, DatePicker)
 |unit-text|element unit for text displaying|Array|`['y', 'M', 'd', 'h', 'm']`|`text-render` for complex logic|
 |text-render|customized option for text displaying|Function(typeFormat, column0Value, column1Value, ...): String|-|`unit-text` is invalid when using `text-render`, refer to `Appendix`|              
 |today-text|displaying text of today|String|`today`|use `&` to take placeholder date, like `&(today)`| 
-|line-height|line height of options|Number|`45`|unit `px`|          
+|line-height|line height of options|Number|`45`|unit `px`| 
+|keep-index|keep last stop position when the column data changes|Boolean|`false`|-|          
 |is-view|inline-display in page, otherwise it shows as `Popup`|Boolean|`false`|-| 
 |title|title of date-picker|String|-|-|
 |describe|description of date-picker|String|-|-|

--- a/components/date-picker/README.md
+++ b/components/date-picker/README.md
@@ -30,7 +30,8 @@ Vue.component(DatePicker.name, DatePicker)
 |unit-text|元素单位展示文案设置|Array|`['年', '月', '日', '时', '分']`|复杂逻辑使用`text-render`|
 |text-render|自定义选项展示文案方法|Function(typeFormat, column0Value, column1Value, ...): String|-|如果使用`text-render`则`unit-text`无效, 示例见附录|
 |today-text|今天展示文案设置|String|`今天`|使用`&`可占位日期数字，如`&(今天)`| 
-|line-height|选择器选项行高|Number|`45`|单位`px`|          
+|line-height|选择器选项行高|Number|`45`|单位`px`|  
+|keep-index|当列数据变化时保持上次停留的位置|Boolean|`false`|-|        
 |is-view|是否内嵌在页面内展示, 否则以弹层形式|Boolean|`false`|-| 
 |title|选择器标题|String|-|-|
 |describe|选择器描述|String|-|-|

--- a/components/date-picker/demo/cases/demo2.vue
+++ b/components/date-picker/demo/cases/demo2.vue
@@ -3,8 +3,9 @@
     <md-date-picker
       ref="datePicker"
       type="datetime"
-      :min-date="currentDate"
+      :default-date="currentDate"
       is-view
+      keep-index
     ></md-date-picker>
   </div>
 </template>
@@ -23,7 +24,6 @@ export default {
   data() {
     return {
       currentDate: new Date(),
-      minDate: new Date('2018/8/30 11:30'),
     }
   },
   mounted() {

--- a/components/date-picker/index.vue
+++ b/components/date-picker/index.vue
@@ -14,6 +14,7 @@
       :large-radius="largeRadius"
       :is-view="isView"
       :mask-closable="maskClosable"
+      :keep-index="keepIndex"
       @initialed="$emit('initialed')"
       @change="$_onPickerChange"
       @confirm="$_onPickerConfirm"
@@ -352,7 +353,7 @@ export default {
         Minute: this.currentMinutes
       }
       args.map(item => {
-        defaultArguments[item.type] = item.value
+        item && (defaultArguments[item.type] = item.value)
       })
       return defaultArguments
     },

--- a/components/picker/README.en-US.md
+++ b/components/picker/README.en-US.md
@@ -29,6 +29,7 @@ Vue.component(Picker.name, Picker)
 |invalid-index|indexes of disabled items in each column|Array|`[]`|array of multiple disabled items, such as `[[1,2], 2]`|
 |is-view|inline display in page, otherwise it shows as `Popup`|Boolean|`false`|-|
 |is-cascade|data in each column is cascaded or not|Boolean|`false`|see #Appendix for the format of cascaded data|
+|keep-index|keep last stop position when the column data changes|Boolean|`false`|only for cascaded data|  
 |line-height|line height of options|Number|`45`|unit `px`|
 |title|title of picker|String|-|-|
 |describe|description of picker|String|-|-|

--- a/components/picker/README.md
+++ b/components/picker/README.md
@@ -30,6 +30,7 @@ Vue.component(Picker.name, Picker)
 |line-height|选择器选项行高|Number|`45`|单位`px`|
 |is-view|是否内嵌在页面内展示，否则以弹层形式|Boolean|`false`|-|
 |is-cascade|各列数据是否级联|Boolean|`false`|级联数据格式见附录|
+|keep-index|当列数据变化时保持上次停留的位置|Boolean|`false`|仅用于级联数据|  
 |title|选择器标题|String|-|-|
 |describe|选择器描述|String|-|-|
 |ok-text|选择器确认文案|String|`确认`|-|

--- a/components/picker/index.vue
+++ b/components/picker/index.vue
@@ -11,6 +11,7 @@
         :default-index="defaultIndex"
         :invalid-index="invalidIndex"
         :line-height="lineHeight"
+        :keep-index="keepIndex"
         :cols="cols"
         @initialed="$emit('initialed')"
         @change="$_onPickerChange"
@@ -45,6 +46,7 @@
           :default-index="$_getDefaultIndex()"
           :invalid-index="invalidIndex"
           :line-height="lineHeight"
+          :keep-index="keepIndex"
           :cols="cols"
           @initialed="$_onPickerInitialed"
           @change="$_onPickerChange"
@@ -145,6 +147,10 @@ export default {
     // },
     // lineHeight: {
     //   type: Boolean,
+    // },
+    // keepIndex: {
+    //   type: Boolean,
+    //   default: false,
     // },
   },
 

--- a/components/picker/mixins/index.js
+++ b/components/picker/mixins/index.js
@@ -17,5 +17,9 @@ export default {
     lineHeight: {
       type: Number,
     },
+    keepIndex: {
+      type: Boolean,
+      default: false,
+    },
   },
 }

--- a/components/picker/test/index.spec.js
+++ b/components/picker/test/index.spec.js
@@ -98,4 +98,28 @@ describe('Picker - Operation', () => {
         .classes('disabled'),
     ).toBe(true)
   })
+
+  test('picker keep index', done => {
+    wrapper = mount(Picker, {
+      propsData: {
+        data: district,
+        isView: true,
+        isCascade: true,
+        keepIndex: true,
+        cols: 3,
+        defaultIndex: [3, 2, 1],
+      },
+    })
+    setTimeout(() => {
+      expect(wrapper.vm.column.activedIndexs[0]).toBe(3)
+
+      const hook = wrapper.findAll('.md-picker-column-hook').at(0)
+      triggerTouch(hook.element, 'touchstart', 0, 0)
+      triggerTouch(hook.element, 'touchmove', 0, 108)
+      triggerTouch(hook.element, 'touchend')
+
+      expect(wrapper.vm.column.activedIndexs[1]).toBe(2)
+      done()
+    }, 500)
+  })
 })


### PR DESCRIPTION
<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
Picker 和 DatePicker 列数据发生变化时，后面所有列默认回到顶部，某些场景体验不佳。通过增加`keep-index`，控制当前一列数据发生变化时，后面列保留上次一停留位置。

### 主要改动
<!-- 列举具体改动点 -->
在列数据发生变化时
* 设置列数据时不再[默认回到顶部](https://github.com/didi/mand-mobile/blob/feat_picker_keep_index/components/picker/picker-column.vue#L486)
* 在列scoller重新初始化后，增加[resetScrollerPosition](https://github.com/didi/mand-mobile/blob/feat_picker_keep_index/components/picker/picker-column.vue#L230)


### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->
当列数据长度变更时，上一次停留位置超出可选范围的异常处理。如上一次选中3月31日，切换至2月
<!-- PR 内容区 -->