### PR TITLE
fix(tab-bar): error in calculating the width of tab items

### DIFF
--- a/components/tab-bar/index.vue
+++ b/components/tab-bar/index.vue
@@ -195,7 +195,8 @@ export default {
 
       let contentWidth = 0
       for (let i = 0, len = this.items.length; i < len; i++) {
-        contentWidth += this.$refs.items[i].offsetWidth
+        const {width} = this.$refs.items[i].getBoundingClientRect()
+        contentWidth += width
       }
       this.contentW = contentWidth
       this.$refs.scroller.reflowScroller()


### PR DESCRIPTION
<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
TabBar在计算是否可滚动时的contentWidth是所有item宽度之和，但是当item宽度存在小数点时，使用offsetWidth无法取到精确值而造成1px左右误差，使得contentWidth大于wrapperWidth而出现滚动。如iphone6 safari

### 主要改动
<!-- 列举具体改动点 -->
item宽度获取由offsetWidth，改为getBoundingClientRect

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->

<!-- PR 内容区 -->