### PR TITLE
Add the ability to configure base units globally.

### DIFF
--- a/components/_style/mixin/theme.basic.styl
+++ b/components/_style/mixin/theme.basic.styl
@@ -1,6 +1,9 @@
 /// Brand Color
 color-primary           = #2F86F6 // 品牌色
 
+/// Basic unit
+hd = 1px
+
 /// Text Color
 color-text-base         = #111A34 // 重要信息，如一级标题
 color-text-base-inverse = #FFF
@@ -24,15 +27,15 @@ color-bg-tap            = #F9FAFB // 条目点击态
 color-mask              = rgba(37, 38, 45, .7) // 弹窗蒙层
 
 /// Text Size
-font-heading-large  = 60px
-font-heading-medium = 52px
-font-heading-normal = 44px
-font-caption-large  = 36px
-font-caption-normal = 32px
-font-body-large     = 28px
-font-body-normal    = 26px
-font-minor-large    = 24px
-font-minor-normal   = 20px
+font-heading-large  = 60*hd
+font-heading-medium = 52*hd
+font-heading-normal = 44*hd
+font-caption-large  = 36*hd
+font-caption-normal = 32*hd
+font-body-large     = 28*hd
+font-body-normal    = 26*hd
+font-minor-large    = 24*hd
+font-minor-normal   = 20*hd
 
 font-weight-light    = 300
 font-weight-normal   = 400
@@ -40,24 +43,24 @@ font-weight-medium   = 500
 font-weight-semibold = 600
 
 /// Radius Size
-radius-normal = 4px
+radius-normal = 4*hd
 radius-circle = 50%
 
 /// Border Size
-border-width-base = 2px
+border-width-base = 2*hd
 
 /// Spacing size
-h-gap-xs = 8px
-h-gap-sm = 12px
-h-gap-md = 20px
-h-gap-lg = 32px
-h-gap-sl = 40px
+h-gap-xs = 8*hd
+h-gap-sm = 12*hd
+h-gap-md = 20*hd
+h-gap-lg = 32*hd
+h-gap-sl = 40*hd
 
-v-gap-xs = 8px
-v-gap-sm = 12px
-v-gap-md = 20px
-v-gap-lg = 32px
-v-gap-sl = 40px
+v-gap-xs = 8*hd
+v-gap-sm = 12*hd
+v-gap-md = 20*hd
+v-gap-lg = 32*hd
+v-gap-sl = 40*hd
 
 /// Transition
 ease-in-out-quint = cubic-bezier(.86, 0, .07, 1)

--- a/components/_style/mixin/theme.components.styl
+++ b/components/_style/mixin/theme.components.styl
@@ -1,14 +1,14 @@
 /// action-bar
 action-bar-width = 100%
-action-bar-height = 100px
+action-bar-height = 100*hd
 action-bar-padding-v = v-gap-md
 action-bar-padding-h = h-gap-sl
-action-bar-button-gap = 22px
+action-bar-button-gap = 22*hd
 action-bar-slot-height = button-height
 action-bar-zindex = 100
 
 /// action-sheet
-action-sheet-height = 120px
+action-sheet-height = 120*hd
 action-sheet-padding-h = h-gap-sl
 action-sheet-color = color-text-body
 action-sheet-color-highlight = color-primary
@@ -57,11 +57,11 @@ button-primary-plain-color = button-primary-fill
 button-warning-plain-color = button-warning-fill
 button-disabled-plain-color = color-text-disabled
 
-button-height = 100px
+button-height = 100*hd
 button-font-size = font-caption-large
 button-font-weight = font-weight-medium
 
-button-small-height = 64px
+button-small-height = 64*hd
 button-small-font-size = font-body-large
 
 button-radius = radius-normal
@@ -82,11 +82,11 @@ captcha-btn-color = color-primary
 cashier-bg = color-bg-inverse
 cashier-choose-title-font-size = font-body-large // 支付标题
 cashier-choose-title-color = color-text-minor
-cashier-choose-amount-font-size = 80px // 支付金额
+cashier-choose-amount-font-size = 80*hd // 支付金额
 cashier-choose-amount-color = color-text-base
 cashier-choose-describe-font-size = font-minor-normal // 支付描述
 cashier-choose-describe-color = color-text-minor
-cashier-choose-channel-title-font-size = 30px // 支付渠道标题
+cashier-choose-channel-title-font-size = 30*hd // 支付渠道标题
 cashier-choose-channel-title-color = color-text-body
 cashier-choose-channel-title-action-font-size = font-body-large // 支付渠道动作标题
 cashier-choose-channel-title-action-color = color-primary
@@ -100,13 +100,13 @@ cashier-choose-more-color = color-text-minor
 chart-line-color = #ccc
 chart-path-color = color-primary
 chart-text-color = color-text-minor
-chart-label-size = 22px
-chart-value-size = 20px
+chart-label-size = 22*hd
+chart-value-size = 20*hd
 
 /// cell-item
-cell-item-min-height = 100px
-cell-item-padding-v = 32px
-cell-item-multilines-padding-v = 36px
+cell-item-min-height = 100*hd
+cell-item-padding-v = 32*hd
+cell-item-multilines-padding-v = 36*hd
 cell-item-title-color = color-text-base
 cell-item-title-font-size = font-caption-normal
 cell-item-brief-color = color-text-caption
@@ -127,11 +127,11 @@ checkbox-border-color = color-border-element
 checkbox-border-radius = radius-normal
 
 /// codebox
-codebox-font-size = 50px
-codebox-width = 66px
-codebox-height = 70px
-codebox-gutter = 18px
-codebox-border-width = 2px
+codebox-font-size = 50*hd
+codebox-width = 66*hd
+codebox-height = 70*hd
+codebox-gutter = 18*hd
+codebox-border-width = 2*hd
 codebox-border-color = color-border-element
 codebox-border-active-color = color-text-base
 codebox-color = color-text-base
@@ -145,25 +145,25 @@ date-picker-font-size = font-caption-normal
 date-time-picker-font-size = font-body-large
 
 /// dialog
-dialog-width = 606px
-dialog-radius = 12px
-dialog-body-padding = 52px
-dialog-title-font-size = 40px
+dialog-width = 606*hd
+dialog-radius = 12*hd
+dialog-body-padding = 52*hd
+dialog-title-font-size = 40*hd
 dialog-title-color = color-text-base
 dialog-text-font-size = font-body-large
 dialog-action-font-weight = font-weight-medium
 dialog-text-color = color-text-minor
-dialog-action-height = 100px
+dialog-action-height = 100*hd
 dialog-action-font-size = font-caption-large
 dialog-action-border-color = color-border-base
 dialog-close-color = color-text-caption
 dialog-action-highlight-color = color-primary
-dialog-icon-size = 100px
+dialog-icon-size = 100*hd
 dialog-icon-fill = color-text-caption
 dialog-zindex = 1500
 
 /// drop-menu
-drop-menu-height = 110px
+drop-menu-height = 110*hd
 drop-menu-bar-bg = color-bg-inverse
 drop-menu-bar-border-color = color-border-base
 drop-menu-list-bg = color-bg-inverse
@@ -189,10 +189,10 @@ field-action-color = color-text-caption
 field-action-font-size = font-minor-large
 
 /// field-item
-field-item-min-height = 100px
-field-item-padding-v = 30px
-field-item-title-width = 160px
-field-item-title-gap = 10px
+field-item-min-height = 100*hd
+field-item-padding-v = 30*hd
+field-item-title-width = 160*hd
+field-item-title-gap = 10*hd
 field-item-color = color-text-base
 field-item-font-size = font-caption-normal
 field-item-font-weight = font-weight-medium
@@ -209,25 +209,25 @@ detail-item-content-color = color-text-body
 detail-item-gap = v-gap-sm
 
 /// icon
-icon-size-xss = 16px
-icon-size-xs = 20px
-icon-size-sm = 24px
-icon-size-md = 32px
-icon-size-lg = 42px
+icon-size-xss = 16*hd
+icon-size-xs = 20*hd
+icon-size-sm = 24*hd
+icon-size-md = 32*hd
+icon-size-lg = 42*hd
 icon-font-family = url("https://manhattan.didistatic.com/static/manhattan/mand-mobile/icon/2.0.2/iconfont.woff") format("woff"), url("https://manhattan.didistatic.com/static/manhattan/mand-mobile/icon/2.0.2/iconfont.ttf") format("truetype")
 
 /// image-viewer
-image-viewer-index-font-size = 32px
-image-viewer-index-bottom = 100px
+image-viewer-index-font-size = 32*hd
+image-viewer-index-bottom = 100*hd
 image-viewer-zindex = 1001
 
 /// input-item
-input-item-height = 100px
+input-item-height = 100*hd
 input-item-font-size = font-caption-normal
 input-item-font-weight = font-weight-medium
 input-item-font-weight-android = bold
 input-item-title-latent-font-size = font-body-normal
-input-item-font-size-large = 80px
+input-item-font-size-large = 80*hd
 input-item-font-size-error = font-minor-large
 input-item-font-size-brief = font-minor-large
 input-item-color = color-text-base
@@ -257,7 +257,7 @@ slider-bg-tap = color-primary
 slider-handle-bg = color-bg-inverse
 
 /// landscape
-landscape-width = 540px
+landscape-width = 540*hd
 // landscape-radius = radius-normal
 landscape-fullscreen-bg = color-bg-inverse
 landscape-zindex = 1600
@@ -266,7 +266,7 @@ landscape-zindex = 1600
 notice-bar-fill = rgba(89, 158, 248, .08)
 notice-bar-font-size = font-body-normal
 notice-bar-color = color-primary
-notice-bar-border-radius = 32px
+notice-bar-border-radius = 32*hd
 notice-bar-fill-warning = #FFEEEF
 notice-bar-color-warning = #FF5B60
 notice-bar-fill-activity = #FFEDDE
@@ -275,9 +275,9 @@ notice-bar-zindex = 999
 
 /// number-keyboard
 number-keyboard-width = 100%
-number-keyboard-height = 428px
+number-keyboard-height = 428*hd
 number-keyboard-bg = color-bg-base
-number-keyboard-key-height = 107px
+number-keyboard-key-height = 107*hd
 number-keyboard-key-bg = color-bg-inverse
 number-keyboard-key-bg-tap = color-bg-base
 number-keyboard-key-confirm-bg = color-primary
@@ -301,13 +301,13 @@ picker-zindex = 1100
 
 /// popup
 popup-title-bar-bg = color-bg-inverse
-popup-title-bar-height = 120px
-popup-title-bar-height-large = 180px
-popup-title-bar-radius = 8px
-popup-title-bar-radius-large = 40px
+popup-title-bar-height = 120*hd
+popup-title-bar-height-large = 180*hd
+popup-title-bar-radius = 8*hd
+popup-title-bar-radius-large = 40*hd
 popup-title-bar-font-size-button = font-caption-large
 popup-title-bar-font-weight-button = font-weight-medium
-popup-title-bar-font-size-title = 40px
+popup-title-bar-font-size-title = 40*hd
 popup-title-bar-font-size-describe = font-body-large
 popup-title-bar-color-title = color-text-base
 popup-title-bar-color-describe = color-text-caption
@@ -320,7 +320,7 @@ popup-zindex = 1000
 radio-color = color-text-highlight
 
 /// result-page
-result-page-image-size = 260px
+result-page-image-size = 260*hd
 result-page-title-font-size = font-caption-normal
 result-page-describe-font-size = font-body-large
 result-page-title-color = color-text-base
@@ -337,21 +337,21 @@ stepper-disabled-opacity = opacity-disabled
 stepper-color = color-text-base
 stepper-font-size = font-body-large
 stepper-input-font-size = font-body-normal
-stepper-height = 50px
-stepper-width-button = 54px
-stepper-width-input = 68px
-stepper-radius-button = 2px
+stepper-height = 50*hd
+stepper-width-button = 54*hd
+stepper-width-input = 68*hd
+stepper-radius-button = 2*hd
 stepper-radius-input = 0
 
 /// steps
 steps-color = color-border-base
 steps-color-active = color-primary
-steps-border-size = 1px
-steps-icon-size = 32px // icon size
+steps-border-size = 1*hd
+steps-icon-size = 32*hd // icon size
 steps-text-color = color-text-body
 steps-text-font-size = font-body-large
-steps-text-gap-horizontal = 20px
-steps-text-gap-vertical = 40px
+steps-text-gap-horizontal = 20*hd
+steps-text-gap-vertical = 40*hd
 steps-desc-color = color-text-caption
 steps-desc-font-size = font-body-normal
 steps-transition-delay = .15s
@@ -372,33 +372,33 @@ tab-text-color = color-text-minor
 tab-active-color = color-primary
 tab-disabled-color = color-text-disabled
 tab-bg = color-bg-base
-tab-height = 100px
-tab-ink-height = 3px
+tab-height = 100*hd
+tab-ink-height = 3*hd
 tab-offset = h-gap-sl
 tab-item-gap = h-gap-md
 
 /// tab-picker
-tab-picker-height = 500px
+tab-picker-height = 500*hd
 tab-picker-h-gap = h-gap-sl
 tab-picker-bg = color-bg-inverse
 tab-picker-zindex = 1102
 
 /// tag
 tag-color = color-primary
-tag-fillet-radius = 2px
+tag-fillet-radius = 2*hd
 tag-large-font-size = font-body-normal
 tag-small-font-size = font-minor-normal
-tag-tiny-font-size = 12px
+tag-tiny-font-size = 12*hd
 
 /// tip
 tip-fill = #41485D
 tip-fill-opacity = .8
 tip-font-size = font-minor-large
 tip-color = color-text-base-inverse
-tip-radius = 1000px
-tip-padding = 15px 32px
-tip-close-size = 32px
-tip-shadow = 0 5px 20px rgba(0, 0, 0, .08)
+tip-radius = 1000*hd
+tip-padding = 15*hd 32*hd
+tip-close-size = 32*hd
+tip-shadow = 0 5*hd 20*hd rgba(0, 0, 0, .08)
 tip-zindex = 1303
 
 /// toast
@@ -406,7 +406,7 @@ toast-fill = rgba(65, 72, 93, .77)
 toast-font-size = font-body-large
 toast-color = #fff
 toast-radius = radius-normal
-toast-padding = 20px 30px
+toast-padding = 20*hd 30*hd
 toast-zindex = 1700
 
 


### PR DESCRIPTION
<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
mand的设计稿纸宽度是750px，而我的设计稿纸是375px，当我使用它的时候，我想使它们的设计稿纸同步，都按照“375px”。当我打开全局主题时，发现没有全局配置单位长度的地方，所以我想添加一个全局配置单位长度的功能，来解决我所遇到的问题。

### 主要改动
<!-- 列举具体改动点 -->
将components>mixin底下所有"px"修改成单位长度"1hd"，这样用户在主题定制的时候就可以使用"1hd"来定制自己喜欢的设计稿纸。

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->
这个功能我觉得挺有必要的，望采纳~ovo

<!-- PR 内容区 -->
