### PR TITLE
fix(tab-bar): fix resize behavior in keep-alive mode

### DIFF
--- a/components/tab-bar/index.vue
+++ b/components/tab-bar/index.vue
@@ -128,6 +128,7 @@ export default {
       })
     },
     items() {
+      /* istanbul ignore next */
       this.$nextTick(function() {
         this.reflow()
       })
@@ -138,6 +139,7 @@ export default {
       })
     },
     scrollable() {
+      /* istanbul ignore next */
       this.scrollerTmpKey = Date.now()
     },
   },
@@ -150,6 +152,14 @@ export default {
   },
   mounted() {
     this.$_resizeEnterBehavior()
+  },
+  activated() {
+    /* istanbul ignore next */
+    this.$_resizeEnterBehavior()
+  },
+  deactivated() {
+    /* istanbul ignore next */
+    this.$_resizeLeaveBehavior()
   },
   beforeDestroy() {
     this.$_resizeLeaveBehavior()


### PR DESCRIPTION

<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
修复 keep-alive 模式下 tab-bar 的 resize 行为
### 主要改动
<!-- 列举具体改动点 -->
tab-bar 在 keep-alive 下 两个生命周期，绑定和解绑 resize 事件
### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->
无
<!-- PR 内容区 -->
