### PR TITLE
fix(stepper): data binding trigger unnecessary checks & maximum and minimum check release boundary value

### DIFF
--- a/components/stepper/index.vue
+++ b/components/stepper/index.vue
@@ -15,6 +15,7 @@
         :value="currentNum"
         :readOnly="readOnly"
         @input="$_onInput"
+        @focus="$_onFocus"
         @blur="$_onChange">
     </div>
     <div
@@ -94,6 +95,7 @@ export default {
     return {
       isMin: false,
       isMax: false,
+      isEditing: false,
       currentNum: 0,
     }
   },
@@ -113,6 +115,9 @@ export default {
       this.currentNum = this.$_getCurrentNum(val)
     },
     value(val) {
+      if (this.isEditing) {
+        return
+      }
       this.currentNum = this.$_getCurrentNum(val)
     },
     min(val) {
@@ -178,8 +183,8 @@ export default {
       return Math.max(Math.min(this.max, this.$_formatNum(value)), this.min)
     },
     $_checkStatus() {
-      this.isMin = subtr(this.currentNum, this.step) < this.min
-      this.isMax = accAdd(this.currentNum, this.step) > this.max
+      this.isMin = this.currentNum <= this.min
+      this.isMax = this.currentNum >= this.max
     },
     $_checkMinMax() {
       if (this.min > this.max) {
@@ -197,7 +202,11 @@ export default {
       }
       this.currentNum = formatted
     },
+    $_onFocus() {
+      this.isEditing = true
+    },
     $_onChange() {
+      this.isEditing = false
       this.currentNum = this.$_getCurrentNum(this.currentNum)
     },
   },

--- a/components/stepper/test/index.spec.js
+++ b/components/stepper/test/index.spec.js
@@ -72,14 +72,30 @@ describe('Stepper Operation', () => {
   test('stepper method checkStatus', () => {
     wrapper = mount(Stepper)
     wrapper.vm.min = 2
+    wrapper.vm.max = 5
     wrapper.vm.currentNum = 3
     wrapper.vm.step = 2
     wrapper.vm.$_checkStatus()
+    expect(wrapper.vm.isMin).toBe(false)
+    wrapper.vm.$_reduce()
+    expect(wrapper.vm.currentNum).toBe(2)
     expect(wrapper.vm.isMin).toBe(true)
+    wrapper.vm.currentNum = 4
+    wrapper.vm.$_checkStatus()
+    expect(wrapper.vm.isMax).toBe(false)
+    wrapper.vm.$_add()
+    expect(wrapper.vm.currentNum).toBe(5)
+    expect(wrapper.vm.isMax).toBe(true)
   })
 
   test('stepper input', () => {
-    wrapper = mount(Stepper)
+    wrapper = mount(Stepper, {
+      listeners: {
+        input(val) {
+          wrapper.setProps({value: val})
+        },
+      },
+    })
     const input = wrapper.find('input')
     triggerTouch(input.element, 'focus')
     triggerTouch(input.element, 'input', 0, 0, 5)


### PR DESCRIPTION
<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
#614 
1. 当存在数据双向绑定时，input修改可能会立即触发数据自动修正，导致无法正常输入
2. 对于边界值的限制过于严格，即对于当前值在限制区间内，但加减step之后会在限制区间外的情况，不做限制，加减后靠自动修正回到限制区间内

### 主要改动
<!-- 列举具体改动点 -->
1. 增加编辑中的状态，当input修改中不触发数据自动修正
2. 使用当前值而不是加减step后的值 判断是否在限制区间内逻辑

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->
是否引入其他边界情况
<!-- PR 内容区 -->