### PR TITLE
fix(popup-title-bar): remove scoped prop in style tag

### DIFF
--- a/components/popup/title-bar.vue
+++ b/components/popup/title-bar.vue
@@ -132,7 +132,7 @@ export default {
 }
 </script>
 
-<style lang="stylus" scoped>
+<style lang="stylus">
 .md-popup-title-bar
   position relative
   width 100%


### PR DESCRIPTION
<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
去除scoped标识，导致产出的css带module标识 #618 

### 主要改动
<!-- 列举具体改动点 -->

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->

<!-- PR 内容区 -->