### PR TITLE
feat(landscape): add props transition for landscape & correct some typos

### DIFF
--- a/components/landscape/README.en-US.md
+++ b/components/landscape/README.en-US.md
@@ -19,13 +19,13 @@ Vue.component(Landscape.name, Landscape)
 ### API
 
 #### Landscape Props
-|Props | Description | Type | Default |
-|----|-----|------|------|
-|v-model|display popup layer or not|Boolean|`false`|
-|has-mask|has mask or not|Boolean|`true`|
-|mask-closable|if popup layer can be closed through clicking on the mask|Boolean|`false`|
-|full-screen|whether display as full screen|Boolean|`false`|
-
+|Props | Description | Type | Default | Note |
+|----|-----|------|------|----- |
+|v-model|display popup layer or not|Boolean|`false`| - |
+|has-mask|has mask or not|Boolean|`true`| - |
+|mask-closable|if popup layer can be closed through clicking on the mask|Boolean|`false`| - |
+|full-screen|whether display as full screen|Boolean|`false`| - |
+| transition | the animation effect of dialog | String | when `full-screen` is `true`, the default value is `md-fade`;otherwise the default value is `md-punch` |refer to [Transition](https://didi.github.io/mand-mobile/#/en-US/docs/components/feedback/transition?anchor=API) for optional values |
 #### Landscape Events
 
 ##### @show()

--- a/components/landscape/README.md
+++ b/components/landscape/README.md
@@ -19,12 +19,13 @@ Vue.component(Landscape.name, Landscape)
 ### API
 
 #### Landscape Props
-|属性 | 说明 | 类型 | 默认值|
-|----|-----|------|------|
-|v-model|是否展示|Boolean|`false`|
-|has-mask|是否有蒙层|Boolean|`true`|
-|mask-closable|是否可以通过点击蒙层关闭|Boolean|`false`|
-|full-screen|是否全屏|Boolean|`false`|
+|属性 | 说明 | 类型 | 默认值| 备注 |
+|----|-----|------|------|-----|
+|v-model|是否展示|Boolean|`false`| - |
+|has-mask|是否有蒙层|Boolean|`true`| - |
+|mask-closable|是否可以通过点击蒙层关闭|Boolean|`false`| - |
+|full-screen|是否全屏|Boolean|`false`| - |
+|transition|弹出层过渡动画|String|`full-screen`为`true`时，默认值`md-fade`；否则默认为`md-punch`| 可选值参考[Transition](https://didi.github.io/mand-mobile/#/zh-CN/docs/components/feedback/transition?anchor=API) |
 
 #### Landscape Events
 

--- a/components/landscape/demo/cases/demo0.vue
+++ b/components/landscape/demo/cases/demo0.vue
@@ -59,6 +59,11 @@
     <md-landscape v-model="showListen" @show="alert('已弹出')" @hide="alert('已隐藏')">
       <img src="//manhattan.didistatic.com/static/manhattan/do1_6VL7HL8TYaUMsIfygfpz">
     </md-landscape>
+
+    <md-button @click="showCustomTransition=true">自定义动画</md-button>
+    <md-landscape v-model="showCustomTransition" transition="md-bounce">
+      <img src="//manhattan.didistatic.com/static/manhattan/do1_6VL7HL8TYaUMsIfygfpz">
+    </md-landscape>
   </div>
 </template>
 
@@ -80,6 +85,7 @@ export default {
       showFullScreen: false,
       showListen: false,
       showMaskClosable: false,
+      showCustomTransition: false,
     }
   },
   methods: {

--- a/components/landscape/index.vue
+++ b/components/landscape/index.vue
@@ -6,7 +6,7 @@
       prevent-scroll
       prevent-scroll-exclude=".md-landscape-content"
       :has-mask="!fullScreen && hasMask"
-      :transition="fullScreen ? 'md-fade' : 'md-punch'"
+      :transition="transition"
       @input="$emit('input', false)"
       @show="$emit('show')"
       @hide="$emit('hide')">
@@ -56,6 +56,12 @@ export default {
     maskClosable: {
       type: Boolean,
       default: false,
+    },
+    transition: {
+      type: String,
+      default() {
+        return this.fullScreen ? 'md-fade' : 'md-punch'
+      },
     },
   },
 

--- a/components/popup/README.md
+++ b/components/popup/README.md
@@ -26,7 +26,7 @@ Vue.component(PopupTitleBar.name, PopupTitleBar)
 |has-mask|是否有蒙层|Boolean|`true`|-|
 |mask-closable|点击蒙层是否可关闭弹出层|Boolean|`true`|-|
 |position|弹出层位置|String|`center`|`center`, `top`, `bottom`, `left`, `right`|
-|transition|弹出层过度动画|String|-|`fade`, `fade-bounce`, `fade-slide`, `fade-zoom`<br> `slide-up`, `slide-down`, `slide-left`, `slide-right`|
+|transition|弹出层过渡动画|String|-|`fade`, `fade-bounce`, `fade-slide`, `fade-zoom`<br> `slide-up`, `slide-down`, `slide-left`, `slide-right`|
 
 #### PopupTitleBar Props
 |属性 | 说明 | 类型 | 默认值 | 备注|

--- a/components/radio/README.en-US.md
+++ b/components/radio/README.en-US.md
@@ -51,7 +51,6 @@ Check multiple radios. Combine with `Radio` or `RadioBox` <sup class="version-af
 | Props | Description | Type | Default | Note |
 |----|-----|------|------|------|
 |v-model|selected names|Array|-|-|
-|max|max selected name length|Number|`0`|`0`: no limit|
 
 #### RadioGroup Methods
 

--- a/components/radio/README.md
+++ b/components/radio/README.md
@@ -54,7 +54,6 @@ Vue.component(RadioList.name, RadioList)
 |属性 | 说明 | 类型 | 默认值 | 备注 |
 |----|-----|------|------|------|
 |v-model|选中的值|Array|-|-|
-|max|最多选择几个|Number|`0`|0为不限制|
 
 #### RadioGroup Methods
 


### PR DESCRIPTION
<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
为 `landscape` 添加 `transition` 属性，使用户能自选动画 
### 主要改动
<!-- 列举具体改动点 -->
1. 为 `landscape` 添加 `transition` 属性
2. 修改了文档的一些错别字
### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->
无
<!-- PR 内容区 -->
