### PR TITLE
fix: supplement safe-area padding and remove unused

### DIFF
--- a/components/action-bar/index.vue
+++ b/components/action-bar/index.vue
@@ -78,6 +78,7 @@ export default {
   display flex
   flex 1
   padding-bottom constant(safe-area-inset-bottom)
+  padding-bottom env(safe-area-inset-bottom)
   
 .md-action-bar-text
   display flex

--- a/components/drop-menu/index.vue
+++ b/components/drop-menu/index.vue
@@ -203,7 +203,6 @@ export default {
   left 0
   right 0
   height drop-menu-height
-  padding-bottom constant(safe-area-inset-bottom)
   box-sizing border-box
   color color-text-minor
   font-size drop-menu-font-size

--- a/components/number-keyboard/index.vue
+++ b/components/number-keyboard/index.vue
@@ -144,4 +144,5 @@ export default {
     padding-top 1px
     background-color color-bg-base
     padding-bottom constant(safe-area-inset-bottom)
+    padding-bottom env(safe-area-inset-bottom)
 </style>

--- a/components/picker/picker-column.vue
+++ b/components/picker/picker-column.vue
@@ -517,7 +517,6 @@ export default {
   position relative
   width 100%
   padding 0 picker-padding-h
-  padding-bottom constant(safe-area-inset-bottom)
   background color-bg-inverse
   box-sizing border-box
   transform translate3d(0, 0, 0)


### PR DESCRIPTION
<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
ActionBar, NumberKeyboard 补充底部安全区留白兼容写法，Picker，Selector，DropMenu底部安全区不留白

### 主要改动
<!-- 列举具体改动点 -->