### PR TITLE
fix(picker&date-picker): handling when rolling too fast & remove redu…

### DIFF
--- a/components/date-picker/test/__snapshots__/demo.spec.js.snap
+++ b/components/date-picker/test/__snapshots__/demo.spec.js.snap
@@ -10,16 +10,6 @@ exports[`DatePicker - Demo Custom type and option textual values 1`] = `
         <div class="md-picker-column-list">
           <div class="md-picker-column-item">
             <ul class="column-list" style="padding-top: 100px; margin-top: -100px;">
-              <li class="column-item" style="height: 45px; line-height: 45px;">1999年</li>
-              <li class="column-item" style="height: 45px; line-height: 45px;">2000年</li>
-              <li class="column-item" style="height: 45px; line-height: 45px;">2001年</li>
-              <li class="column-item" style="height: 45px; line-height: 45px;">2002年</li>
-              <li class="column-item" style="height: 45px; line-height: 45px;">2003年</li>
-              <li class="column-item" style="height: 45px; line-height: 45px;">2004年</li>
-              <li class="column-item" style="height: 45px; line-height: 45px;">2005年</li>
-              <li class="column-item" style="height: 45px; line-height: 45px;">2006年</li>
-              <li class="column-item" style="height: 45px; line-height: 45px;">2007年</li>
-              <li class="column-item" style="height: 45px; line-height: 45px;">2008年</li>
               <li class="column-item" style="height: 45px; line-height: 45px;">2009年</li>
               <li class="column-item" style="height: 45px; line-height: 45px;">2010年</li>
               <li class="column-item" style="height: 45px; line-height: 45px;">2011年</li>
@@ -29,8 +19,8 @@ exports[`DatePicker - Demo Custom type and option textual values 1`] = `
               <li class="column-item" style="height: 45px; line-height: 45px;">2015年</li>
               <li class="column-item" style="height: 45px; line-height: 45px;">2016年</li>
               <li class="column-item" style="height: 45px; line-height: 45px;">2017年</li>
-              <li class="column-item active" style="height: 45px; line-height: 45px;">2018年</li>
-              <li class="column-item" style="height: 45px; line-height: 45px;">2019年</li>
+              <li class="column-item" style="height: 45px; line-height: 45px;">2018年</li>
+              <li class="column-item active" style="height: 45px; line-height: 45px;">2019年</li>
               <li class="column-item" style="height: 45px; line-height: 45px;">2020年</li>
               <li class="column-item" style="height: 45px; line-height: 45px;">2021年</li>
               <li class="column-item" style="height: 45px; line-height: 45px;">2022年</li>
@@ -41,16 +31,6 @@ exports[`DatePicker - Demo Custom type and option textual values 1`] = `
               <li class="column-item" style="height: 45px; line-height: 45px;">2027年</li>
               <li class="column-item" style="height: 45px; line-height: 45px;">2028年</li>
               <li class="column-item" style="height: 45px; line-height: 45px;">2029年</li>
-              <li class="column-item" style="height: 45px; line-height: 45px;">2030年</li>
-              <li class="column-item" style="height: 45px; line-height: 45px;">2031年</li>
-              <li class="column-item" style="height: 45px; line-height: 45px;">2032年</li>
-              <li class="column-item" style="height: 45px; line-height: 45px;">2033年</li>
-              <li class="column-item" style="height: 45px; line-height: 45px;">2034年</li>
-              <li class="column-item" style="height: 45px; line-height: 45px;">2035年</li>
-              <li class="column-item" style="height: 45px; line-height: 45px;">2036年</li>
-              <li class="column-item" style="height: 45px; line-height: 45px;">2037年</li>
-              <li class="column-item" style="height: 45px; line-height: 45px;">2038年</li>
-              <li class="column-item" style="height: 45px; line-height: 45px;">2039年</li>
             </ul>
           </div>
           <div class="md-picker-column-item">
@@ -70,8 +50,8 @@ exports[`DatePicker - Demo Custom type and option textual values 1`] = `
             </ul>
           </div>
           <div class="md-picker-column-item">
-            <ul class="column-list" style="padding-top: 100px; margin-top: -100px;">
-              <li class="column-item" style="height: 45px; line-height: 45px;">*1日</li>
+            <ul class="column-list" style="padding-top: 100px;">
+              <li class="column-item active" style="height: 45px; line-height: 45px;">*1日</li>
               <li class="column-item" style="height: 45px; line-height: 45px;">*2日</li>
               <li class="column-item" style="height: 45px; line-height: 45px;">*3日</li>
               <li class="column-item" style="height: 45px; line-height: 45px;">*4日</li>
@@ -80,7 +60,7 @@ exports[`DatePicker - Demo Custom type and option textual values 1`] = `
               <li class="column-item" style="height: 45px; line-height: 45px;">*7日</li>
               <li class="column-item" style="height: 45px; line-height: 45px;">*8日</li>
               <li class="column-item" style="height: 45px; line-height: 45px;">*9日</li>
-              <li class="column-item active" style="height: 45px; line-height: 45px;">*10日</li>
+              <li class="column-item" style="height: 45px; line-height: 45px;">*10日</li>
               <li class="column-item" style="height: 45px; line-height: 45px;">*11日</li>
               <li class="column-item" style="height: 45px; line-height: 45px;">*12日</li>
               <li class="column-item" style="height: 45px; line-height: 45px;">*13日</li>
@@ -242,6 +222,7 @@ exports[`DatePicker - Demo Date & Time selection 1`] = `
               <li class="column-item" style="height: 45px; line-height: 45px;">2037年</li>
               <li class="column-item" style="height: 45px; line-height: 45px;">2038年</li>
               <li class="column-item" style="height: 45px; line-height: 45px;">2039年</li>
+              <li class="column-item" style="height: 45px; line-height: 45px;">2040年</li>
             </ul>
           </div>
           <div class="md-picker-column-item">

--- a/components/date-picker/test/cases/demo3.vue
+++ b/components/date-picker/test/cases/demo3.vue
@@ -6,6 +6,8 @@
       title="选择出险时间"
       :text-render="textRender"
       :custom-types="['yyyy', 'MM','dd', 'hh', 'mm']"
+      :min-date="minDate"
+      :max-date="maxDate"
       :default-date="currentDate"
       is-view
     ></md-date-picker>
@@ -21,7 +23,9 @@ export default {
   },
   data() {
     return {
-      currentDate: new Date('2018/10/10'),
+      currentDate: new Date('2019-10-01 00:00'),
+      minDate: new Date('2009-10-01'),
+      maxDate: new Date('2029-10-01'),
     }
   },
   methods: {

--- a/components/picker/picker-column.vue
+++ b/components/picker/picker-column.vue
@@ -422,6 +422,7 @@ export default {
 
       if (isInvalid || activeItemIndex === this.activedIndexs[index]) {
         isInvalid && this.$_scrollToValidIndex(scroller, index, activeItemIndex)
+        activeItemIndex === this.activedIndexs[index] && this.$_scrollToIndex(scroller, index, activeItemIndex)
         return false
       }
 
@@ -557,7 +558,7 @@ export default {
 .md-picker-column-list
   display flex
   height 100%
-  padding 0 picker-padding-h
+  // padding 0 picker-padding-h
 
 .md-picker-column-item
   position relative


### PR DESCRIPTION
### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
1. 当快速滚动多个列时，因前一列滚动还未结束，回导致当前列滚动无法正确拿到滚动位置，从而导致无法确定activeItemIndex。#632
2. picker-column和picker-column-list上都存在`padding 0 40px`，导致内容区域拥挤

### 主要改动
<!-- 列举具体改动点 -->
1. 兜底处理，重新定位到起始位置
2. 去掉picker-column-list上padding

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->