### PR TITLE
fix(textarea-item): avoid height calculations

### DIFF
--- a/components/textarea-item/index.vue
+++ b/components/textarea-item/index.vue
@@ -172,6 +172,11 @@ export default {
       textarea.style.height = 'auto'
 
       let scrollHeight = textarea.scrollHeight
+      // if textarea-item is not displayed, avoid height calculations
+      if (scrollHeight === 0) {
+        return
+      }
+
       if (this.maxHeightInner && scrollHeight > this.maxHeightInner) {
         scrollHeight = this.maxHeightInner
       }

--- a/components/textarea-item/test/index.spec.js
+++ b/components/textarea-item/test/index.spec.js
@@ -5,7 +5,12 @@ import triggerEvent from '../../popup/test/touch-trigger'
 describe('TextareaItem - Operation', () => {
   let wrapper
 
+  beforeEach(() => {
+    Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', {configurable: true, value: 0})
+  })
+
   afterEach(() => {
+    // Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', { configurable: true, value: 0 })
     wrapper && wrapper.destroy()
   })
 
@@ -33,7 +38,6 @@ describe('TextareaItem - Operation', () => {
     expect(wrapper.vm.maxHeightInner).toBe('200')
     const textarea = wrapper.vm.$refs.textarea
     triggerEvent(textarea, 'focus', 0, 0)
-    triggerEvent(textarea, 'focus', 0, 0)
     textarea.style.height = '342px'
     triggerEvent(textarea, 'input', 0, 0, '禁用文本域, 理赔报案描述, 理赔报案描述, 理赔报案描述, 理赔报案描述, 理赔报案描述, 理赔报案描述')
     triggerEvent(textarea, 'keydown', 0, 0, 49)
@@ -41,9 +45,19 @@ describe('TextareaItem - Operation', () => {
     triggerEvent(textarea, 'blur', 0, 0)
 
     // 测试高度适应
-    wrapper.setProps({maxHeight: '-1'})
+    // scrollHeight 总是0, 很难模拟到srollHeight的计算过程
+    // https://github.com/testing-library/react-testing-library/issues/353
+    Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', {configurable: true, value: 30})
     wrapper.setProps({value: '123'})
-    expect(wrapper.vm.$refs.textarea.style.height).toBe('-1px')
+    expect(textarea.style.height).toBe('30px')
+
+    wrapper.setProps({maxHeight: '20'})
+    expect(textarea.style.height).toBe('20px')
+
+    // 当scrollHeight为0时, 不改变textarea的高度
+    Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', {configurable: true, value: 0})
+    wrapper.setProps({value: '123'})
+    expect(textarea.style.height).toBe('20px')
   })
 
   test('focus and blur', done => {
@@ -59,7 +73,7 @@ describe('TextareaItem - Operation', () => {
     wrapper.vm.blur()
     setTimeout(() => {
       done()
-    }, 120)
+    }, 220)
     wrapper.vm.focus()
   })
 


### PR DESCRIPTION

### 背景
在popup组件里使用textarea-item, 高度始终是0

### 主要改动
textarea-item组件,在初始化的时候,如果组件这个没有显示出来(比如display:none), 这个时候计算的scrollHeight是0, 然后display:block的时候并没有重新计算scrollHeight, 这个时候组件的高度任然是0