### PR TITLE
fix(swiper): autoplay fails  when userScrolling

### DIFF
--- a/components/swiper/index.vue
+++ b/components/swiper/index.vue
@@ -220,7 +220,7 @@ export default {
       }
       /* istanbul ignore if */
       if (this.userScrolling) {
-        this.$_doOnTouchEnd(e)
+        this.play(this.duration)
 
         this.dragging = false
         this.dragState = {}

--- a/components/swiper/index.vue
+++ b/components/swiper/index.vue
@@ -220,6 +220,8 @@ export default {
       }
       /* istanbul ignore if */
       if (this.userScrolling) {
+        this.$_doOnTouchEnd(e)
+
         this.dragging = false
         this.dragState = {}
         return


### PR DESCRIPTION


### 背景描述

如果是userScrolling(用户只是想上下滑动屏幕,不是左右滑动滑块), autoplay意外被中断

复现: https://didi.github.io/mand-mobile/examples/#/swiper 第一个swiper, 鼠标按住想上滑一下, 松手, 即可复现

### 主要改动

滑动结束, 恢复自动播放