### PR TITLE
fix(tip): mark scrolling wrapper in ScrollView

### DIFF
--- a/components/scroll-view/index.vue
+++ b/components/scroll-view/index.vue
@@ -18,6 +18,7 @@
       :class="{
         'horizon': scrollingX && !scrollingY
       }"
+      scroll-wrapper
     >
       <div
         v-if="hasRefresher"

--- a/components/selector/test/__snapshots__/demo.spec.js.snap
+++ b/components/selector/test/__snapshots__/demo.spec.js.snap
@@ -34,7 +34,7 @@ exports[`Selector - Demo Check mode 1`] = `
         <div class="md-selector-container">
           <div class="md-scroll-view" style="max-height:auto;min-height:320px;">
             <!---->
-            <div class="scroll-view-container">
+            <div scroll-wrapper="" class="scroll-view-container">
               <!---->
               <div class="md-radio-list md-selector-list">
                 <div class="md-cell-item md-radio-item">
@@ -148,7 +148,7 @@ exports[`Selector - Demo Confirmed mode 1`] = `
         <div class="md-selector-container">
           <div class="md-scroll-view" style="max-height:auto;min-height:320px;">
             <!---->
-            <div class="scroll-view-container">
+            <div scroll-wrapper="" class="scroll-view-container">
               <!---->
               <div class="md-radio-list md-selector-list">
                 <div class="md-cell-item md-radio-item">
@@ -259,7 +259,7 @@ exports[`Selector - Demo Custom options 1`] = `
         <div class="md-selector-container">
           <div class="md-scroll-view" style="max-height:auto;min-height:auto;">
             <!---->
-            <div class="scroll-view-container">
+            <div scroll-wrapper="" class="scroll-view-container">
               <!---->
               <div class="selector-header">
                 Header Slot
@@ -405,7 +405,7 @@ exports[`Selector - Demo Multi mode 1`] = `
         <div class="md-selector-container">
           <div class="md-scroll-view" style="max-height:auto;min-height:320px;">
             <!---->
-            <div class="scroll-view-container">
+            <div scroll-wrapper="" class="scroll-view-container">
               <!---->
               <div class="md-check-group md-check-list md-selector-list">
                 <div class="md-cell-item md-check-item is-checked">
@@ -516,7 +516,7 @@ exports[`Selector - Demo No need to confirm 1`] = `
         <div class="md-selector-container">
           <div class="md-scroll-view" style="max-height:320px;min-height:auto;">
             <!---->
-            <div class="scroll-view-container">
+            <div scroll-wrapper="" class="scroll-view-container">
               <!---->
               <div class="md-radio-list md-selector-list">
                 <div class="md-cell-item md-radio-item">

--- a/components/tab-bar/test/__snapshots__/demo.spec.js.snap
+++ b/components/tab-bar/test/__snapshots__/demo.spec.js.snap
@@ -7,7 +7,7 @@ exports[`TabBar - Demo Basic 1`] = `
       <!---->
       <div class="md-scroll-view">
         <!---->
-        <div class="scroll-view-container">
+        <div scroll-wrapper="" class="scroll-view-container">
           <!---->
           <div class="md-tab-bar-list" style="width:0px;"><a class="md-tab-bar-item is-active">标签1</a><a class="md-tab-bar-item">标签2</a></div> <span class="md-tab-bar-ink" style="width:0px;transform:translateX(0px);"></span>
           <!---->
@@ -26,7 +26,7 @@ exports[`TabBar - Demo Custom Item 1`] = `
       <!---->
       <div class="md-scroll-view">
         <!---->
-        <div class="scroll-view-container">
+        <div scroll-wrapper="" class="scroll-view-container">
           <!---->
           <div class="md-tab-bar-list" style="width:0px;"><a class="md-tab-bar-item is-active"><i class="md-icon icon-font md-icon-arrow-up arrow-up md" style="color:;"></i> <span>标签1</span></a><a class="md-tab-bar-item"><i class="md-icon icon-font md-icon-arrow-right arrow-right md" style="color:;"></i> <span>标签2</span></a><a class="md-tab-bar-item"><i class="md-icon icon-font md-icon-arrow-down arrow-down md" style="color:;"></i> <span>标签3</span></a><a class="md-tab-bar-item"><i class="md-icon icon-font md-icon-arrow-left arrow-left md" style="color:;"></i> <span>标签4</span></a></div> <span class="md-tab-bar-ink" style="width:0px;transform:translateX(0px);"></span>
           <!---->
@@ -45,7 +45,7 @@ exports[`TabBar - Demo Max length 1`] = `
       <!---->
       <div class="md-scroll-view">
         <!---->
-        <div class="scroll-view-container">
+        <div scroll-wrapper="" class="scroll-view-container">
           <!---->
           <div class="md-tab-bar-list" style="width:0px;"><a class="md-tab-bar-item is-active">标签1</a><a class="md-tab-bar-item">标签2</a><a class="md-tab-bar-item">标签3</a><a class="md-tab-bar-item">标签4</a><a class="md-tab-bar-item">标签5</a></div> <span class="md-tab-bar-ink" style="width:0px;transform:translateX(0px);"></span>
           <!---->
@@ -64,7 +64,7 @@ exports[`TabBar - Demo No ink 1`] = `
       <!---->
       <div class="md-scroll-view">
         <!---->
-        <div class="scroll-view-container">
+        <div scroll-wrapper="" class="scroll-view-container">
           <!---->
           <div class="md-tab-bar-list" style="width:0px;"><a class="md-tab-bar-item is-active">标签1</a><a class="md-tab-bar-item">标签2</a><a class="md-tab-bar-item">标签3</a></div>
           <!---->
@@ -84,7 +84,7 @@ exports[`TabBar - Demo Scroll 1`] = `
       <!---->
       <div class="md-scroll-view">
         <!---->
-        <div class="scroll-view-container">
+        <div scroll-wrapper="" class="scroll-view-container">
           <!---->
           <div class="md-tab-bar-list" style="width:0px;"><a class="md-tab-bar-item is-active">精选</a><a class="md-tab-bar-item">全部</a><a class="md-tab-bar-item">满减券</a><a class="md-tab-bar-item">立减券</a><a class="md-tab-bar-item">免息券</a><a class="md-tab-bar-item">校园专享</a><a class="md-tab-bar-item">夜间优惠</a><a class="md-tab-bar-item">红包</a></div> <span class="md-tab-bar-ink" style="width:0px;transform:translateX(0px);"></span>
           <!---->

--- a/components/tab-picker/test/__snapshots__/demo.spec.js.snap
+++ b/components/tab-picker/test/__snapshots__/demo.spec.js.snap
@@ -22,7 +22,7 @@ exports[`TabPicker - Demo Basic 1`] = `
                 <!---->
                 <div class="md-scroll-view">
                   <!---->
-                  <div class="scroll-view-container">
+                  <div scroll-wrapper="" class="scroll-view-container">
                     <!---->
                     <div class="md-tab-bar-list" style="width:0px;"></div> <span class="md-tab-bar-ink" style="width:0px;transform:translateX(0px);"></span>
                     <!---->
@@ -34,7 +34,7 @@ exports[`TabPicker - Demo Basic 1`] = `
             <div class="md-tabs-content">
               <div class="md-scroll-view">
                 <!---->
-                <div class="scroll-view-container">
+                <div scroll-wrapper="" class="scroll-view-container">
                   <!---->
                   <div role="tabpanel" tab="province" name="md-tab-slide-left" class="md-tab-pane">
                     <div class="md-radio-list">

--- a/components/tabs/test/__snapshots__/demo.spec.js.snap
+++ b/components/tabs/test/__snapshots__/demo.spec.js.snap
@@ -8,7 +8,7 @@ exports[`Tabs - Demo Basic 1`] = `
         <!---->
         <div class="md-scroll-view">
           <!---->
-          <div class="scroll-view-container">
+          <div scroll-wrapper="" class="scroll-view-container">
             <!---->
             <div class="md-tab-bar-list" style="width:0px;"></div> <span class="md-tab-bar-ink" style="width:0px;transform:translateX(0px);"></span>
             <!---->

--- a/components/tip/index.js
+++ b/components/tip/index.js
@@ -113,8 +113,9 @@ export default {
 
       const overflowY = window.getComputedStyle(node).overflowY
       const isScrollable = overflowY !== 'visible' && overflowY !== 'hidden'
+      const isScrollView = node && node.getAttribute('scroll-wrapper') !== null
 
-      if (isScrollable && node.scrollHeight > node.clientHeight) {
+      if ((isScrollable && node.scrollHeight > node.clientHeight) || isScrollView) {
         return node
       } else {
         return this.$_getFirstScrollWrapper(node.parentNode)

--- a/components/tip/test/index.spec.js
+++ b/components/tip/test/index.spec.js
@@ -1,4 +1,5 @@
 import TipContent from 'mand-mobile/components/tip/tip'
+import TipWrapper from './tip-wrapper'
 import sinon from 'sinon'
 import {mount} from '@vue/test-utils'
 
@@ -53,5 +54,12 @@ describe('Tip', () => {
 
     wrapper.find('.md-icon-close').trigger('click')
     expect(eventStub.calledWith('close')).toBe(true)
+  })
+
+  it('scroll-wrapper', () => {
+    wrapper = mount(TipWrapper)
+    const wrapperEl = wrapper.vm.$refs.tip.wrapperEl
+    console.log(wrapperEl.className)
+    expect(wrapperEl.className).toBe('wrapper1')
   })
 })

--- a/components/tip/test/tip-wrapper.vue
+++ b/components/tip/test/tip-wrapper.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="wrapper0">
+    <div class="wrapper1" scroll-wrapper>
+      <md-tip content="不错哟" placement="top" ref="tip">
+        <md-button type="default">点击我</md-button>
+      </md-tip>
+    </div>
+  </div>
+</template>
+
+<script>import Button from '../../button'
+import Tip from '../index'
+export default {
+  components: {
+    [Tip.name]: Tip,
+    [Button.name]: Button,
+  },
+}
+</script>>  


### PR DESCRIPTION
<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
当Tip在ScrollView中使用时，因为Scrollview内部是模拟滚动，所以tip展示时因为无法准确选中滚动容器而导致位置计算错误。

### 主要改动
<!-- 列举具体改动点 -->
Scrollview中通过`scroll-wrapper`属性标记出滚动容器，tip内部判断滚动容器的条件增加是否具有该标记。
PS: 该标记属性也可用于用户自定义布局中通过`translate`实现的模拟滚动场景

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->

<!-- PR 内容区 -->
