### PR TITLE
feat(captcha): add prop auto-send for trigger send event automatically

### DIFF
--- a/components/captcha/README.en-US.md
+++ b/components/captcha/README.en-US.md
@@ -25,7 +25,8 @@ Vue.component(Captcha.name, Captcha)
 | maxlength | maxlength of string, set to `-1` as no restriction | Number | 4 |
 | mask | whether to mask code or not | Boolean | `false` |
 | system | Use system keyboard or simulated keyboard | Boolean | `false` |
-| auto-countdown |start the countdown automatically, otherwise need to manually call `countdown`|Boolean|`true`|
+| auto-send <sup class="version-after">2.5.8+</sup> |whether the `send` event is triggered during the first display, otherwise you need to manually click the send button|Boolean|`true`|
+| auto-countdown |whether to automatically start the countdown after manually clicking the send button, otherwise you need to manually call `countdown`|Boolean|`true`|
 | title |-|String|-|
 | brief |-|String|-|-|
 | append-to | portal node of dialog | HTML Element | `document.body` |

--- a/components/captcha/README.md
+++ b/components/captcha/README.md
@@ -26,7 +26,8 @@ Vue.component(Captcha.name, Captcha)
 |maxlength|字符最大输入长度, 若为`-1`则不限制输入长度|Number|`4`|
 |mask|是否掩码|Boolean|`false`|
 |system|是否使用系统默认键盘|Boolean|`false`|
-|auto-countdown|是否自动开始倒计时，否则需手动调用`countdown`|Boolean|`true`|
+|auto-send <sup class="version-after">2.5.8+</sup> |第一次展示时是否触发`send`事件，否则需手动点击发送按钮|Boolean|`true`|
+|auto-countdown|手动点击发送按钮后是否自动开始倒计时，否则需手动调用`countdown`|Boolean|`true`|
 |title|标题|String|-|
 |brief|描述|String|-|
 |append-to|挂载节点|HTMLElement|`document.body`|

--- a/components/captcha/index.vue
+++ b/components/captcha/index.vue
@@ -114,6 +114,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    autoSend: {
+      type: Boolean,
+      default: true,
+    },
     autoCountdown: {
       type: Boolean,
       default: true,
@@ -156,7 +160,7 @@ export default {
         this.code = ''
         if (!this.firstShown) {
           this.firstShown = true
-          this.$_onResend()
+          this.$_emitSend()
         }
       }
     },
@@ -173,7 +177,7 @@ export default {
     }
     if (this.value || this.isView) {
       this.firstShown = true
-      this.$_onResend()
+      this.$_emitSend()
     }
   },
 
@@ -206,6 +210,9 @@ export default {
         this.countdown()
       }
       this.$emit('send', this.countdown)
+    },
+    $_emitSend() {
+      this.autoSend && this.$_onResend()
     },
     // MARK: public methods
     countdown() {

--- a/components/captcha/test/index.spec.js
+++ b/components/captcha/test/index.spec.js
@@ -126,6 +126,25 @@ describe('Captcha - Operation', () => {
     }, 2500)
   })
 
+  it('auto send', done => {
+    wrapper = mount(Captcha, {
+      propsData: {
+        autoSend: false,
+      },
+    })
+
+    const eventStub = sinon.stub(wrapper.vm, '$emit')
+    wrapper.setProps({
+      value: true,
+    })
+    expect(eventStub.calledWith('send')).toEqual(false)
+    setTimeout(() => {
+      wrapper.find('.md-captcha-btn').trigger('click')
+      expect(eventStub.calledWith('send')).toEqual(true)
+      done()
+    }, 2500)
+  })
+
   it('not countdown', () => {
     wrapper = mount(Captcha, {
       propsData: {


### PR DESCRIPTION
<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
验证码第一次展示时，默认自动触发了`send`事件，无法控制此时机

### 主要改动
<!-- 列举具体改动点 -->
增加属性`auto-send`，当其为`false`时，验证码第一次展示不自动触发`send`事件，需用户点击`发送`按钮后触发

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->

<!-- PR 内容区 -->