### PR TITLE
fix(scroll-view): fix scroll-view-refresh wrong emit refreshActive

### DIFF
--- a/components/scroll-view/index.vue
+++ b/components/scroll-view/index.vue
@@ -185,11 +185,11 @@ export default {
           () => {
             this.isRefreshActive = true
             this.isRefreshing = false
+            this.$emit('refreshActive')
           },
           () => {
             this.isRefreshActive = false
             this.isRefreshing = false
-            this.$emit('refreshActive')
           },
           () => {
             this.isRefreshActive = false


### PR DESCRIPTION
fix #642 

### 背景描述
scroll-view使用scroll-view-refresh组件，下拉刷新，手势滑动到最底部并没有触发refreshActive事件，而是在向上滑动时才会触发

### 主要改动
修改refreshActive事件触发位置

### 需要注意
无
