### PR TITLE
doc(tabs): fix double padding

### DIFF
--- a/components/tabs/demo/cases/demo0.vue
+++ b/components/tabs/demo/cases/demo0.vue
@@ -14,7 +14,8 @@
   </div>
 </template>
 
-<script>import {Tabs, TabPane} from 'mand-mobile'
+<script>
+import {Tabs, TabPane} from 'mand-mobile'
 
 export default {
   name: 'tab-bar-demo',
@@ -26,12 +27,13 @@ export default {
     [TabPane.name]: TabPane,
   },
 }
-</script>
+
+</script>
 
 <style lang="stylus">
 .md-example-child-tabs
   .content
-    padding 12px 0
+    margin 12px 0
     font-size 28px
     background #FFF
     padding 20px


### PR DESCRIPTION
### 背景描述
官方文档demo实例代码错误

### 主要改动
旧
```css
  .content
    padding 12px 0     <----------
    font-size 28px
    background #FFF
    padding 20px
    line-height 1.5
    box-sizing border-box
```
新
```css
  .content
    margin 12px 0     <----------
    font-size 28px
    background #FFF
    padding 20px
    line-height 1.5
    box-sizing border-box
```
### 需要注意
无