### PR TITLE
feat(check-group): add method for full selection and reverse selection

### DIFF
--- a/components/check/README.en-US.md
+++ b/components/check/README.en-US.md
@@ -73,6 +73,13 @@ Check multiple checks. Combine with `Check` or `CheckBox`.
 |----|-----|------|------|
 |name|name will be toggle|String|-|
 
+##### toggleAll(checked?: Boolean)
+Select All or Deselect (`disabled` options will not be changed) <sup class="version-after">2.5.9+</sup>
+
+| Arg | Description | Type | Default |
+|----|-----|------|------|
+|checked|select all or none|Boolean|reverse election if empty|
+
 ---
 
 #### CheckList Props

--- a/components/check/README.md
+++ b/components/check/README.md
@@ -71,6 +71,13 @@ Vue.component(CheckList.name, CheckList)
 |----|-----|------|------|
 |name|需要反选的键值|String|-|
 
+##### toggleAll(checked?: Boolean)
+全选或者反选（对`disabled`的选项不改变其原选中状态）<sup class="version-after">2.5.9+</sup>
+
+|参数 | 说明 | 类型 | 默认值 |
+|----|-----|------|------|
+|checked|全选或全不选|Boolean|如果传空，则反选|
+
 ---
 
 #### CheckList Props

--- a/components/check/box.vue
+++ b/components/check/box.vue
@@ -46,6 +46,13 @@ export default {
     rootGroup: {default: null},
   },
 
+  mounted() {
+    this.rootGroup && this.rootGroup.register(this)
+  },
+  destroyed() {
+    this.rootGroup && this.rootGroup.unregister(this)
+  },
+
   methods: {
     $_onClick() {
       if (this.disabled) {

--- a/components/check/demo/cases/demo4.vue
+++ b/components/check/demo/cases/demo4.vue
@@ -2,16 +2,21 @@
   <div class="md-example-child md-example-child-check md-example-child-check-4">
     <md-field title="复选列表">
       <md-check-list
+        ref="checkList"
         v-model="favorites"
         icon="right"
         icon-inverse=""
         :options="fruits"
       />
+      <md-cell-item no-border>
+        <md-button type="primary" size="small" inline @click="checkAll">全选</md-button>
+        <md-button size="small" inline @click="toggleAll">反选</md-button>
+      </md-cell-item>
     </md-field>
 	</div>
 </template>
 
-<script>import {Field, CheckList} from 'mand-mobile'
+<script>import {Field, CellItem, CheckList, Button} from 'mand-mobile'
 
 export default {
   name: 'check-demo',
@@ -21,7 +26,9 @@ export default {
   /* DELETE */
   components: {
     [Field.name]: Field,
+    [CellItem.name]: CellItem,
     [CheckList.name]: CheckList,
+    [Button.name]: Button,
   },
   data() {
     return {
@@ -34,6 +41,14 @@ export default {
         {value: 'tomato', label: '西红柿', disabled: true},
       ],
     }
+  },
+  methods: {
+    checkAll() {
+      this.$refs.checkList.$refs.group.toggleAll(true)
+    },
+    toggleAll() {
+      this.$refs.checkList.$refs.group.toggleAll()
+    },
   },
 }
 </script>

--- a/components/check/group.vue
+++ b/components/check/group.vue
@@ -27,6 +27,12 @@ export default {
     },
   },
 
+  data() {
+    return {
+      children: {},
+    }
+  },
+
   provide() {
     return {
       rootGroup: this,
@@ -34,6 +40,12 @@ export default {
   },
 
   methods: {
+    register(child) {
+      child.name && (this.children[child.name] = child)
+    },
+    unregister(child) {
+      child.name && delete this.children[child.name]
+    },
     check(name) {
       const index = this.value.indexOf(name)
       if (index === -1 && (this.max < 1 || this.value.length < this.max)) {
@@ -53,6 +65,25 @@ export default {
       } else {
         this.uncheck(name)
       }
+    },
+    toggleAll(checked) {
+      // if (checked === false) {
+      //   this.$emit('input', [])
+      //   return
+      // }
+
+      let {children} = this
+      const names = Object.keys(children).filter(name => {
+        const child = children[name]
+        const isChecked = !!~this.value.indexOf(name)
+
+        // disabled options retain original status
+        if (child.disabled) {
+          return isChecked
+        }
+        return checked === false ? false : !checked ? !isChecked : true
+      })
+      this.$emit('input', names)
     },
   },
 }

--- a/components/check/index.vue
+++ b/components/check/index.vue
@@ -62,6 +62,13 @@ export default {
     rootGroup: {default: null},
   },
 
+  mounted() {
+    this.rootGroup && this.rootGroup.register(this)
+  },
+  destroyed() {
+    this.rootGroup && this.rootGroup.unregister(this)
+  },
+
   methods: {
     $_onClick() {
       if (this.disabled) {

--- a/components/check/test/index.spec.js
+++ b/components/check/test/index.spec.js
@@ -130,6 +130,37 @@ describe('Check - Operation', () => {
     expect(value).toEqual(['b'])
   })
 
+  test('checkbox group toggle', () => {
+    Vue.component(CheckBox.name, CheckBox)
+    let value = ['a']
+    wrapper = mount(CheckGroup, {
+      propsData: {
+        value,
+      },
+      slots: {
+        default: ['<md-check-box name="a"/>', '<md-check-box name="b"/>', '<md-check-box name="c" disabled/>'],
+      },
+      listeners: {
+        input(val) {
+          value = val
+          wrapper.setProps({value})
+        },
+      },
+    })
+
+    const checks = wrapper.findAll('.md-check-box')
+    expect(checks.at(0).classes('is-checked')).toBe(true)
+
+    wrapper.vm.toggleAll()
+    expect(value).toEqual(['b'])
+
+    wrapper.vm.toggleAll(true)
+    expect(value).toEqual(['a', 'b'])
+
+    wrapper.vm.toggleAll(false)
+    expect(value).toEqual([])
+  })
+
   test('checkbox disabled', () => {
     let clicked = false
     wrapper = shallowMount(CheckBox, {


### PR DESCRIPTION
### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
CheckGroup增加全选/全不选和反选功能 #648 

### 主要改动
<!-- 列举具体改动点 -->
CheckGroup增加接口方法toggleAll
```js
toggleAll(true) // 全选
toggleAll(false) // 全不选
toggleAll() // 反选
```

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->
禁用的选项，需保持初始化时的状态，调用toggleAll后不会改变