### PR TITLE
fix(image-reader): avoid importing jpegencoder repeatedly

### DIFF
--- a/components/image-reader/image-processor.js
+++ b/components/image-reader/image-processor.js
@@ -167,7 +167,7 @@ function makeCanvas(img, orientation, maxWidth, maxHeight, quality) {
       ctx.drawImage(img, 0, 0, width, height)
   }
 
-  if (UA.oldIOS || UA.oldAndroid || UA.mQQBrowser || !navigator.userAgent) {
+  if ((UA.oldIOS || UA.oldAndroid || UA.mQQBrowser || !navigator.userAgent) && window.JPEGEncoder) {
     /* global JPEGEncoder */
     const encoder = new JPEGEncoder()
     const newImg = ctx.getImageData(0, 0, canvas.width, canvas.height)
@@ -216,7 +216,7 @@ export default function(options, fn = noop) {
 }
 
 // Import jpeg_encoder_basic for compatibility if necessary
-if (UA.oldIOS || UA.oldAndroid || UA.mQQBrowser || !navigator.userAgent) {
+if ((UA.oldIOS || UA.oldAndroid || UA.mQQBrowser || !navigator.userAgent) && !window.JPEGEncoder) {
   /* istanbul ignore next */
   requireRemoteScript('//manhattan.didistatic.com/static/manhattan/mfd/image-reader/jpeg_encoder_basic.js')
 }


### PR DESCRIPTION
<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
避免jpgencoder库被重复加载（如微前端模式下）

### 主要改动
<!-- 列举具体改动点 -->
侦测并复用全局对象

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->
无
<!-- PR 内容区 -->