### PR TITLE
fix(tab-bar): error in calculating the width of tab wrapper

### DIFF
--- a/components/tab-bar/index.vue
+++ b/components/tab-bar/index.vue
@@ -208,7 +208,8 @@ export default {
         return
       }
 
-      this.wrapperW = this.$refs.wrapper.offsetWidth
+      const wrapperReact = this.$refs.wrapper.getBoundingClientRect()
+      this.wrapperW = wrapperReact.width
 
       let contentWidth = 0
       for (let i = 0, len = this.items.length; i < len; i++) {


### PR DESCRIPTION
<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
跟之前的PR #601 同样的问题，上次只是修复了tab item，tab wrapper的尺寸也同样的问题

### 主要改动
<!-- 列举具体改动点 -->
wrapper宽度获取由offsetWidth，改为getBoundingClientRect

<!-- PR 内容区 -->