### PR TITLE
fix(amount): 修复中文货币单位不正确的问题

### DIFF
--- a/components/amount/demo/cases/demo3.vue
+++ b/components/amount/demo/cases/demo3.vue
@@ -4,6 +4,16 @@
       :value="1234"
       is-capital
     ></md-amount>
+    <br>
+    <md-amount
+      :value="1234.1118"
+      is-capital
+    ></md-amount>
+    <br>
+    <md-amount
+      :value="1234.1010"
+      is-capital
+    ></md-amount>
 	</div>
 </template>
 

--- a/components/amount/number-capital.js
+++ b/components/amount/number-capital.js
@@ -6,8 +6,8 @@ const cnIntRadice = ['', '\u62fe', '\u4f70', '\u4edf']
 // 万 \u4e07 亿 \u4ebf 兆 \u5146
 const cnIntUnits = ['', '\u4e07', '\u4ebf', '兆']
 
-// 角 \u89d2 分 \u5206 毫 \u6beb 厘 \u5398
-const cnDecUnits = ['\u89d2', '\u5206', '\u6beb', '\u5398']
+// 角 \u89d2 分 \u5206 厘 \u5398 毫 \u6beb
+const cnDecUnits = ['\u89d2', '\u5206', '\u5398', '\u6beb']
 const cnInteger = '\u6574' // 整 \u6574
 const cnIntLast = '\u5143' // 元 \u5143
 


### PR DESCRIPTION
<!-- PR 内容区 -->

### 背景描述
修复中文货币单位不正确的问题

### 主要改动
由 `元角分毫厘` 修正为 `元角分厘毫`

### 需要注意
无

<!-- PR 内容区 -->
