### PR TITLE
fix(number-keyboard): avoid repeated triggering of click and touchstart

### DIFF
--- a/components/number-keyboard/key.vue
+++ b/components/number-keyboard/key.vue
@@ -2,18 +2,18 @@
   <li
     v-if="noTouch"
     :class="[active ? 'active' : '']"
-    @click="$_onFocus"
+    @click="$_onFocus($event, 'click')"
   >
     <span v-text="value"></span>
   </li>
   <li
     v-else
     :class="[active ? 'active' : '']"
-    @touchstart="$_onFocus"
+    @touchstart="$_onFocus($event, 'touch')"
     @touchmove="$_onBlur"
     @touchend="$_onBlur"
     @touchcancel="$_onBlur"
-    @click="$_onFocus"
+    @click="$_onFocus($event, 'click')"
   >
     <span v-text="value"></span>
   </li>
@@ -40,18 +40,27 @@
   data() {
     return {
       active: false,
+      activeType: '',
     }
   },
 
   methods: {
-    $_onFocus(event) {
+    $_onFocus(event, type) {
       if (!this.noPrevent) {
         event.preventDefault()
         event.stopImmediatePropagation()
       }
+
+      if (this.activeType && this.activeType !== type) {
+        return
+      }
+
+      this.activeType = type
+
       if (!this.noTouch) {
         this.active = true
       }
+
       this.$emit('press', this.value)
     },
     $_onBlur() {


### PR DESCRIPTION
<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
在部分浏览中，touchstart preventDefault无效，导致touchstart和click会重复触发，从而导致点击动作被重复处理

### 主要改动
<!-- 列举具体改动点 -->
对同时绑定了touchstart和click两种事件进行拦截处理，当toustart被优先触发后，避免click事件再次被响应

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->

<!-- PR 内容区 -->
