### PR TITLE
doc(popup): use propsOnlyClose in jsx or tsx

### DIFF
--- a/components/popup/README.en-US.md
+++ b/components/popup/README.en-US.md
@@ -35,7 +35,7 @@ Vue.component(PopupTitleBar.name, PopupTitleBar)
 |ok-text|confirmation text|String|-|no confirmation button if empty|
 |cancel-text|cancellation text|String|-|no cancellation button if empty|
 |large-radius|large radius|Boolean|`false`|-|
-|only-close|only right close button|Boolean|`false`|-|
+|only-close|only right close button|Boolean|`false`|Use propsOnlyClose in jsx or tsx. [propsOnlyClose](https://github.com/vuejs/babel-plugin-transform-vue-jsx#difference-from-react-jsx)|
 |title-align <sup class="version-after">2.4.0+</sup>|title and description position|String|`center`|note that `left` and `right` will hide the left and right buttons respectively|
 
 #### Popup Events

--- a/components/popup/README.md
+++ b/components/popup/README.md
@@ -36,7 +36,7 @@ Vue.component(PopupTitleBar.name, PopupTitleBar)
 |ok-text|确认按钮文案|String|-|为空则没有确认按钮|
 |cancel-text|取消按钮文案|String|-|为空则没有取消按钮|
 |large-radius <sup class="version-after">2.4.0+</sup>|大圆角模式|Boolean|`false`|-|
-|only-close <sup class="version-after">2.4.0+</sup>|只有右侧关闭按钮|Boolean|`false`|-|
+|only-close <sup class="version-after">2.4.0+</sup>|只有右侧关闭按钮|Boolean|`false`|`jsx` 或 `tsx` 里使用 [propsOnlyClose](https://github.com/vuejs/babel-plugin-transform-vue-jsx#difference-from-react-jsx)|
 |title-align <sup class="version-after">2.4.0+</sup>|标题和描述位置|String|`center`|注意`left`和`right`时会分别隐藏左右两侧按钮|
 
 #### Popup Events


### PR DESCRIPTION
<!-- PR 内容区 -->

### 背景描述
如果使用 `jsx/tsx` 语法，直接使用 `only-close` 属性会受到影响不被 `jsx/tsx` 识别，在 [babel-plugin-transform-vue-jsx](https://github.com/vuejs/babel-plugin-transform-vue-jsx#difference-from-react-jsx) 库提供了 **propsOnXXX** 开头的属性即可被 `jsx/tsx` 识别。

### 主要改动
新增 `only-close` 中英文备注

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->
无
<!-- PR 内容区 -->
