### PR TITLE
fix(tip): Tip components subcomponents are native tags with no properties that will report an error

### DIFF
--- a/components/tip/index.js
+++ b/components/tip/index.js
@@ -76,6 +76,7 @@ export default {
     })
 
     if (firstNode) {
+      firstNode.data = firstNode.data || {}
       const on = (firstNode.data.on = firstNode.data.on || {})
       const nativeOn = (firstNode.data.nativeOn = firstNode.data.nativeOn || {})
 

--- a/components/tip/test/tip-wrapper.vue
+++ b/components/tip/test/tip-wrapper.vue
@@ -2,18 +2,18 @@
   <div class="wrapper0">
     <div class="wrapper1" scroll-wrapper>
       <md-tip content="不错哟" placement="top" ref="tip">
-        <md-button type="default">点击我</md-button>
+        <span>点击我</span>
       </md-tip>
     </div>
   </div>
 </template>
 
-<script>import Button from '../../button'
+<script>
 import Tip from '../index'
 export default {
   components: {
-    [Tip.name]: Tip,
-    [Button.name]: Button,
+    [Tip.name]: Tip
   },
 }
-</script>>  
+
+</script>


### PR DESCRIPTION
### 背景描述
tip 组件子组件是没有属性的原生标签的时候会报错
```
<md-tip content="不错哟" placement="top" ref="tip">
        <span>点击我</span>
</md-tip>
```

### 主要改动
在 `render` 方法里，对 `firstNode.data` 做了一次初始化
```
firstNode.data = firstNode.data || {}
```
修改了测试用例 `tip-wrapper.vue`
使用了没有属性的原生组件做子元素
