### PR TITLE
fix image orientation

### DIFF
--- a/components/image-reader/image-processor.js
+++ b/components/image-reader/image-processor.js
@@ -127,44 +127,48 @@ function makeCanvas(img, orientation, maxWidth, maxHeight, quality) {
   ctx.drawImage(img, 0, 0, width, height)
 
   let base64 = null
-  switch (orientation) {
-    case 3:
-      ctx.rotate(180 * Math.PI / 180)
-      ctx.drawImage(img, -width, -height, width, height)
-      break
-    case 6:
-      ctx.rotate(90 * Math.PI / 180)
-      ctx.drawImage(img, 0, -width, height, width)
-      break
-    case 8:
-      ctx.rotate(270 * Math.PI / 180)
-      ctx.drawImage(img, -height, 0, height, width)
-      break
-    case 2:
-      ctx.translate(width, 0)
-      ctx.scale(-1, 1)
-      ctx.drawImage(img, 0, 0, width, height)
-      break
-    case 4:
-      ctx.translate(width, 0)
-      ctx.scale(-1, 1)
-      ctx.rotate(180 * Math.PI / 180)
-      ctx.drawImage(img, -width, -height, width, height)
-      break
-    case 5:
-      ctx.translate(width, 0)
-      ctx.scale(-1, 1)
-      ctx.rotate(90 * Math.PI / 180)
-      ctx.drawImage(img, 0, -width, height, width)
-      break
-    case 7:
-      ctx.translate(width, 0)
-      ctx.scale(-1, 1)
-      ctx.rotate(270 * Math.PI / 180)
-      ctx.drawImage(img, -height, 0, height, width)
-      break
-    default:
-      ctx.drawImage(img, 0, 0, width, height)
+  if (!CSS.supports('image-orientation:none')) {
+    switch (orientation) {
+      case 3:
+        ctx.rotate(180 * Math.PI / 180)
+        ctx.drawImage(img, -width, -height, width, height)
+        break
+      case 6:
+        ctx.rotate(90 * Math.PI / 180)
+        ctx.drawImage(img, 0, -width, height, width)
+        break
+      case 8:
+        ctx.rotate(270 * Math.PI / 180)
+        ctx.drawImage(img, -height, 0, height, width)
+        break
+      case 2:
+        ctx.translate(width, 0)
+        ctx.scale(-1, 1)
+        ctx.drawImage(img, 0, 0, width, height)
+        break
+      case 4:
+        ctx.translate(width, 0)
+        ctx.scale(-1, 1)
+        ctx.rotate(180 * Math.PI / 180)
+        ctx.drawImage(img, -width, -height, width, height)
+        break
+      case 5:
+        ctx.translate(width, 0)
+        ctx.scale(-1, 1)
+        ctx.rotate(90 * Math.PI / 180)
+        ctx.drawImage(img, 0, -width, height, width)
+        break
+      case 7:
+        ctx.translate(width, 0)
+        ctx.scale(-1, 1)
+        ctx.rotate(270 * Math.PI / 180)
+        ctx.drawImage(img, -height, 0, height, width)
+        break
+      default:
+        ctx.drawImage(img, 0, 0, width, height)
+    }
+  } else {
+    ctx.drawImage(img, 0, 0, width, height)
   }
 
   if ((UA.oldIOS || UA.oldAndroid || UA.mQQBrowser || !navigator.userAgent) && window.JPEGEncoder) {

--- a/components/image-reader/image-processor.js
+++ b/components/image-reader/image-processor.js
@@ -127,7 +127,7 @@ function makeCanvas(img, orientation, maxWidth, maxHeight, quality) {
   ctx.drawImage(img, 0, 0, width, height)
 
   let base64 = null
-  if (!CSS.supports('image-orientation:none')) {
+  if (CSS && CSS.supports && !CSS.supports('image-orientation:none')) {
     switch (orientation) {
       case 3:
         ctx.rotate(180 * Math.PI / 180)


### PR DESCRIPTION
<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
有些浏览器已经做了自动修复图片角度的功能，此时无需再代码修正图片，否则图片再次旋转不符合预期
当浏览器不自动修复图片角度问题时，再用代码修复图片角度。（检测浏览器是否已做修正，在我们线上线上项目运行小半年了，没有问题，此次有兄弟项目组发现该组件拍照有问题，故提出此pr）


### 主要改动
<!-- 列举具体改动点 -->
主要判断了浏览器是否有自动修复的功能，有的话，则不再修正，否则走原来的修正逻辑

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->
可以chrome浏览器试试，此浏览器已做图片修正
<!-- PR 内容区 -->
