### PR TITLE
Revert "chore: update preview.yml"

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,14 +1,12 @@
 name: 🔂 Surge PR Preview
 
-on: pull_request
+on: [push, pull_request]
 
 jobs:
   preview:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
       - uses: afc163/surge-preview@v1
         with:
           surge_token: ${{ secrets.SURGE_TOKEN }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,6 +1,6 @@
 name: 🔂 Surge PR Preview
 
-on: pull_request_target
+on: pull_request
 
 jobs:
   preview:


### PR DESCRIPTION
Reverts didi/mand-mobile#718

`pull_request_target` 配合 `refs/pull/${{ github.event.pull_request.number }}/merge` 有安全隐患，先回滚到 `pull_request`。

https://github.com/afc163/surge-preview/pull/100