### PR TITLE
fix(input-item): shorten interval to set cursor position asynchronously

### DIFF
--- a/components/input-item/cursor.js
+++ b/components/input-item/cursor.js
@@ -34,6 +34,7 @@ export function setCursorsPosition(ctrl, pos) {
     clearTimeout(timer)
   }
 
+  // Compatible with some Android devices, the synchronized settings will be invalid
   timer = setTimeout(() => {
     /* istanbul ignore next */
     if (ctrl.setSelectionRange) {
@@ -46,5 +47,5 @@ export function setCursorsPosition(ctrl, pos) {
       range.moveStart('character', pos)
       range.select()
     }
-  }, 50)
+  }, 0)
 }


### PR DESCRIPTION
<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
格式化的表单，当光标位于中间时，插入字符光标会先回到字符串最后，再回到正确位置 #749 

### 主要改动
<!-- 列举具体改动点 -->
减少设置光标的异步动作延迟时间

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->
兼容问题，部分安卓设备可能会光标设置无效

<!-- PR 内容区 -->