### PR TITLE
fix(ruler): fixed scrolling position when ruler is not initialized

### DIFF
--- a/components/ruler/index.vue
+++ b/components/ruler/index.vue
@@ -164,7 +164,11 @@ export default {
       const drawFn = throttle(this.$_draw, 10)
       const scroller = new Scroller(
         left => {
-          this.isInitialed && drawFn(left)
+          if (this.isInitialed) {
+            drawFn(left)
+          } else {
+            this.$_draw(left)
+          }
         },
         {
           scrollingX: true,


### PR DESCRIPTION

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
初始化时，基于scope的设置存在不可滚动区域时，需修正内部scroller位置（此时ruler初始化未完成），但因为滚动回调内只处理初始化完成后的滚动，所以此修正操作就跳过了，导致ruler位置异常。#748

### 主要改动
<!-- 列举具体改动点 -->
scroller的渲染回调用处理未完成时的动作

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->

<!-- PR 内容区 -->