### PR TITLE
feat: 🎸 optimize component

### DIFF
--- a/components/agree/index.vue
+++ b/components/agree/index.vue
@@ -10,10 +10,7 @@
         value ? 'checked' : ''
       ]"
       @click="$_onChange($event)">
-      <div class="md-agree-icon-container">
-        <md-icon name="checked" :size="size"></md-icon>
-        <md-icon name="check" :size="size"></md-icon>
-      </div>
+        <md-icon :name="currentIcon" :size="size" :svg="iconSvg"/>
     </div>
     <div class="md-agree-content">
       <slot></slot>
@@ -21,7 +18,8 @@
   </div>
 </template>
 
-<script>import Icon from '../icon'
+<script>
+import Icon from '../icon'
 export default {
   name: 'md-agree',
 
@@ -42,12 +40,28 @@ export default {
       type: String,
       default: 'md',
     },
+    iconSvg: {
+      type: Boolean,
+      default: false,
+    },
+    icon: {
+      type: String,
+      default: 'checked',
+    },
+    iconInverse: {
+      type: String,
+      default: 'check',
+    },
   },
 
   data() {
     return {}
   },
-
+  computed: {
+    currentIcon() {
+      return this.value ? this.icon : this.iconInverse
+    },
+  },
   methods: {
     // MARK: events handler, 如 $_onButtonClick
     $_onChange(event) {
@@ -59,7 +73,8 @@ export default {
     },
   },
 }
-</script>
+
+</script>
 
 <style lang="stylus">
 .md-agree

--- a/components/codebox/index.vue
+++ b/components/codebox/index.vue
@@ -40,6 +40,7 @@
           readonly
           disabled
           :class="['md-codebox-holder', focused && 'is-active']"
+          @blur="blur"
         />
         <input
           v-else
@@ -49,6 +50,7 @@
           readonly
           disabled
           :class="['md-codebox-holder', focused && 'is-active']"
+          @blur="blur"
         />
       </template>
     </div>
@@ -61,6 +63,7 @@
         @input="$_onInputChange"
         ref="input"
         class="md-codebox-input"
+        @blur="blur"
       />
     </form>
     <md-number-keyboard
@@ -75,11 +78,14 @@
       @delete="$_onDelete"
       @enter="$_onEnter"
       @confirm="$_onConfirm"
+      @press="focus"
+      @blur="blur"
     ></md-number-keyboard>
   </div>
 </template>
 
-<script>import NumberKeyboard from '../number-keyboard'
+<script>
+import NumberKeyboard from '../number-keyboard'
 
 export default {
   name: 'md-codebox',
@@ -221,6 +227,7 @@ export default {
       if (this.system) {
         this.$refs.input.blur()
       }
+      this.$emit('blur')
     },
     focus() {
       if (this.disabled) {
@@ -231,10 +238,12 @@ export default {
       if (this.system) {
         this.$refs.input.focus()
       }
+      this.$emit('focus')
     },
   },
 }
-</script>
+
+</script>
 
 <style lang="stylus">
 .md-codebox-wrapper

--- a/components/dialog/index.js
+++ b/components/dialog/index.js
@@ -24,6 +24,7 @@ const generate = function({
   btns = [],
   onShow = noop,
   onHide = noop,
+  preventScroll = true,
 }) {
   const DialogConstructor = Vue.extend(Dialog)
   const vm = new DialogConstructor({
@@ -36,7 +37,7 @@ const generate = function({
       closable,
       btns,
       transition,
-      preventScroll: true,
+      preventScroll,
     },
   }).$mount()
 
@@ -87,6 +88,7 @@ Dialog.confirm = ({
   onCancel = noop,
   onShow = noop,
   onHide = noop,
+  preventScroll = true,
 }) => {
   const vm = generate({
     title,
@@ -117,6 +119,7 @@ Dialog.confirm = ({
         },
       },
     ],
+    preventScroll,
   })
 
   return vm
@@ -140,6 +143,7 @@ Dialog.alert = ({
   onConfirm = noop,
   onShow = noop,
   onHide = noop,
+  preventScroll = true,
 }) => {
   const vm = generate({
     title,
@@ -161,6 +165,7 @@ Dialog.alert = ({
         },
       },
     ],
+    preventScroll,
   })
 
   return vm

--- a/components/number-keyboard/key.vue
+++ b/components/number-keyboard/key.vue
@@ -19,7 +19,8 @@
   </li>
 </template>
 
-<script>export default {
+<script>
+export default {
   name: 'md-number-key',
 
   props: {
@@ -65,7 +66,9 @@
     },
     $_onBlur() {
       this.active = false
+      this.$emit('blur')
     },
   },
 }
-</script>
+
+</script>

--- a/components/popup/index.vue
+++ b/components/popup/index.vue
@@ -35,7 +35,8 @@
   </div>
 </template>
 
-<script>import Transition from '../transition'
+<script>
+import Transition from '../transition'
 import popupMixin from './mixins'
 
 export default {
@@ -166,10 +167,11 @@ export default {
     $_preventScroll(isBind) {
       const handler = isBind ? 'addEventListener' : 'removeEventListener'
       const masker = this.$el.querySelector('.md-popup-mask')
-      const boxer = this.$el.querySelector('.md-popup-box')
+      // const boxer = this.$el.querySelector('.md-popup-box')
 
       masker && masker[handler]('touchmove', this.$_preventDefault, false)
-      boxer && boxer[handler]('touchmove', this.$_preventDefault, false)
+      // 修复content不可滚动问题
+      // boxer && boxer[handler]('touchmove', this.$_preventDefault, false)
       this.$_preventScrollExclude(isBind)
     },
     $_preventScrollExclude(isBind, preventScrollExclude) {
@@ -225,7 +227,8 @@ export default {
     },
   },
 }
-</script>
+
+</script>
 
 <style lang="stylus">
 .md-popup


### PR DESCRIPTION
BREAKING CHANGE: 🧨 agree && popup && dialog

## 提交PR前

* 请认真阅读[开发指南](https://didi.github.io/mand-mobile/#/zh-CN/docs/development)
* fork **dev分支**
* 按照规范命名分支
* 需通过测试
* 提交PR至**dev分支**



## 创建PR

* 标题规则：type(scope):description，参考[规范](https://didi.github.io/mand-mobile/#/zh-CN/docs/development?anchor=Commit%E8%A7%84%E8%8C%83)
* 内容描述，参考"PR 内容区"

## 请把以上内容删除，并填写以下内容！！！

<!-- PR 内容区 -->

### 背景描述
1、苹果唤起软键盘后，页面会被向上顶出一块空白，收起后该空白不会自动消失。业界通用的做法时监听输入框的 focus、blur 事件，手动在键盘收起时将页面滚动到顶部。这两个组件没有提供这两个事件，无法做此修复
2、基础组件内的组件存在替换图标的诉求，目前无法满足
3、弹起 popup 后，滚动组件内部到底部后，body 会接着滚动

### 主要改动
<!-- 列举具体改动点 -->
1.agree 支持自定义图标
2.对popup内容过长支持滚动
3.codebox抛出blur事件供业务处理逻辑

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->

<!-- PR 内容区 -->
