### PR TITLE
fix: 用户为svg-icon图标设置auto尺寸问题

### DIFF
--- a/components/icon/index.vue
+++ b/components/icon/index.vue
@@ -94,9 +94,10 @@ export default {
   &.icon-svg
     width 1em
     vertical-height(1em)
-    &.xss
+    width 1em !important
       font-size icon-size-xss
     &.xs
+    vertical-height(1em !important)
       font-size icon-size-xs
     &.sm
       font-size icon-size-sm


### PR DESCRIPTION



## 创建PR

## 请把以上内容删除，并填写以下内容！！！

<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
1、原有的部分功能型icon-font图标会被组件默认转成svg图标（兼容锁定模式）
1、用户侧可能设置了公共尺寸属性，即将width和height设置为auto。
2、svg存在两个尺寸设置，一个是浏览器认为的默认尺寸，一个是组件内设定的默认尺寸。 如果用户侧设置auto后，组件的默认尺寸（1em*1em）会被覆盖，而浏览器会按照默认350px*150px的尺寸渲染。
### 主要改动
<!-- 列举具体改动点 -->
经调研，无法更改svg图标默认尺寸大小。因为将组件内svg icon的默认1em*1em存尺寸 加上!important来覆盖用户侧的auto配置。


### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->
icon font-face的方式设置尺寸通过font-size，默认转成svg后，由于默认宽高是1em， 因此也可以通过font-size方式设定svg图标的尺寸。 原则上不需要再设置width和height属性

<!-- PR 内容区 -->
