### PR TITLE
fix: 删除agree组件中icon的默认宽高样式

### DIFF
--- a/components/agree/index.vue
+++ b/components/agree/index.vue
@@ -95,9 +95,6 @@ export default {
     position relative
     .md-icon
       display flex
-      width auto
-      height auto
-      line-height 1
       will-change auto
       &.md-icon-checked,&.md-icon-square-checked
         position absolute


### PR DESCRIPTION
### 背景描述
组件内为icon的宽高设置了auto属性。导致svg图标会被渲染成默认尺寸（250px x 150px）

### 主要改动
<!-- 列举具体改动点 -->
删除 width:auto 、height:auto、line-height:1
### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->

<!-- PR 内容区 -->
