### PR TITLE
fix(popup-title-bar): vue与vue-template-compiler@2.6.14以上版本报错

### DIFF
--- a/components/popup/title-bar.vue
+++ b/components/popup/title-bar.vue
@@ -3,7 +3,10 @@
     class="md-popup-title-bar"
     :class="[
       `title-align-${titleAlign}`,
-      ...{large: !!describe, 'large-radius': largeRadius}
+      {
+        large: !!describe,
+        'large-radius': largeRadius
+      }
     ]"
     @touchmove="$_preventScroll"
   >
@@ -74,7 +77,8 @@
   </div>
 </template>
 
-<script>import titleBarMixin from './mixins/title-bar'
+<script>
+import titleBarMixin from './mixins/title-bar'
 import Icon from '../icon'
 
 export default {
@@ -130,7 +134,8 @@ export default {
     },
   },
 }
-</script>
+
+</script>
 
 <style lang="stylus" scoped>
 .md-popup-title-bar


### PR DESCRIPTION
<!-- PR 内容区 -->

### 背景描述
<!-- 描述新增功能或修复问题的背景信息 -->
vue与vue-template-compiler@2.6.14以上版本报错
![image](https://user-images.githubusercontent.com/31871202/221808112-5d65cca0-2e5b-40be-b598-917c768a097d.png)


### 主要改动
<!-- 列举具体改动点 -->
修改components/popup/title-bar.vue根节点class

### 需要注意
<!-- 列举需重点review和测试的点，或者其他备注信息 -->

<!-- PR 内容区 -->
