### PR TITLE
amount support mask`

### DIFF
--- a/components/amount/README.en-US.md
+++ b/components/amount/README.en-US.md
@@ -33,4 +33,4 @@ The font `DIDIFD-Medium` is used in the component for the case show only, if nec
 |is-capital|convert to chinese capital|Boolean|`false`|-|
 |transition|use transition when value changes|Boolean|`false`|-|
 |duration|transition duration|Number|`1000`|unit `ms`|
-|mask<sup class="version-after">2.7.2+</sup>|use mask|Boolean|`false`|-|
+|mask<sup class="version-after">2.7.1+</sup>|use mask|Boolean|`false`|-|

--- a/components/amount/README.en-US.md
+++ b/components/amount/README.en-US.md
@@ -33,3 +33,4 @@ The font `DIDIFD-Medium` is used in the component for the case show only, if nec
 |is-capital|convert to chinese capital|Boolean|`false`|-|
 |transition|use transition when value changes|Boolean|`false`|-|
 |duration|transition duration|Number|`1000`|unit `ms`|
+|mask<sup class="version-after">2.7.2+</sup>|use mask|Boolean|`false`|-|

--- a/components/amount/README.md
+++ b/components/amount/README.md
@@ -33,4 +33,4 @@ Vue.component(Amount.name, Amount)
 |is-capital|数字是否转换为大写中文|Boolean|`false`|-|
 |transition|数字变化是否使用动画|Boolean|`false`|-|
 |duration|数字变化动画时长|Number|`1000`|单位`ms`|
-|mask<sup class="version-after">2.7.2+</sup> |是否掩码|Boolean|`false`|-|
+|mask<sup class="version-after">2.7.1+</sup> |是否掩码|Boolean|`false`|-|

--- a/components/amount/README.md
+++ b/components/amount/README.md
@@ -33,3 +33,4 @@ Vue.component(Amount.name, Amount)
 |is-capital|数字是否转换为大写中文|Boolean|`false`|-|
 |transition|数字变化是否使用动画|Boolean|`false`|-|
 |duration|数字变化动画时长|Number|`1000`|单位`ms`|
+|mask<sup class="version-after">2.7.2+</sup> |是否掩码|Boolean|`false`|-|

--- a/components/amount/demo/cases/demo4.vue
+++ b/components/amount/demo/cases/demo4.vue
@@ -15,7 +15,7 @@ export default {
   name: 'amount-demo',
   /* DELETE */
   title: '掩码展示',
-  titleEnUS: 'Capital Chinese',
+  titleEnUS: 'Mask Display',
   /* DELETE */
   components: {
     [Amount.name]: Amount,

--- a/components/amount/demo/cases/demo4.vue
+++ b/components/amount/demo/cases/demo4.vue
@@ -14,7 +14,7 @@
 export default {
   name: 'amount-demo',
   /* DELETE */
-  title: '大写中文',
+  title: '掩码展示',
   titleEnUS: 'Capital Chinese',
   /* DELETE */
   components: {

--- a/components/amount/demo/cases/demo4.vue
+++ b/components/amount/demo/cases/demo4.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="md-example-child md-example-child-amount">
+    <md-amount
+      :value="1234"
+      mask
+      precision="0"
+    ></md-amount>
+    <br>
+	</div>
+</template>
+
+<script>import {Amount} from 'mand-mobile'
+
+export default {
+  name: 'amount-demo',
+  /* DELETE */
+  title: '大写中文',
+  titleEnUS: 'Capital Chinese',
+  /* DELETE */
+  components: {
+    [Amount.name]: Amount,
+  },
+}
+</script>
+
+<style lang="stylus" scoped>
+.md-example-child-amount
+  text-align center
+  font-size 32px
+  color #666
+</style>

--- a/components/amount/demo/index.vue
+++ b/components/amount/demo/index.vue
@@ -15,9 +15,10 @@ import Demo0 from './cases/demo0'
 import Demo1 from './cases/demo1'
 import Demo2 from './cases/demo2'
 import Demo3 from './cases/demo3'
+import Demo4 from './cases/demo4'
 
 export default {
-  ...createDemoModule('amount', [Demo0, Demo1, Demo2, Demo3]),
+  ...createDemoModule('amount', [Demo0, Demo1, Demo2, Demo3, Demo4]),
 }
 </script>
 

--- a/components/amount/index.vue
+++ b/components/amount/index.vue
@@ -1,6 +1,6 @@
 <template>
   <span class="md-amount" :class="{numerical: !isCapital}">
-    <template v-if="!isCapital">{{ formatValue | doPrecision(legalPrecision, isRoundUp) | doFormat(hasSeparator, separator) }}</template> <template v-else> {{ formatValue | doPrecision(4, isRoundUp) | doCapital }} </template>
+    <template v-if="!isCapital">{{ formatValue | doPrecision(legalPrecision, isRoundUp) | doFormat(hasSeparator, separator) | doMask(mask)}}</template> <template v-else> {{ formatValue | doPrecision(4, isRoundUp) | doCapital }} </template>
   </span>
 </template>
 
@@ -17,6 +17,13 @@ export default {
       const exponentialForm = Number(`${value}e${precision}`)
       const rounded = isRoundUp ? Math.round(exponentialForm) : Math.floor(exponentialForm)
       return Number(`${rounded}e-${precision}`).toFixed(precision)
+    },
+    doMask(value, mask) {
+      if (mask) {
+        return value.toString().replace(/\d/g, '*')
+      } else {
+        return value
+      }
     },
     doFormat(value, hasSeparator, separator) {
       if (!hasSeparator) {
@@ -77,6 +84,10 @@ export default {
     duration: {
       type: Number,
       default: 1000,
+    },
+    mask: {
+      type: Boolean,
+      default: false,
     },
   },
 


### PR DESCRIPTION

### 背景描述
信贷需要支持金额显示掩码

### 主要改动
<!-- 列举具体改动点 -->
amount组件新增props mask 用来控制是否支持掩码
### 需要注意
amount展示正常


